### PR TITLE
Fix package name drift: eslint-plugin-agent-code-guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "safer-by-default",
       "source": "./plugins/safer-by-default",
-      "description": "Installs eslint-plugin-safer-by-default, wires eslint.config.js and tsconfig strict flags, and applies safer-by-default principles to ongoing TypeScript work.",
+      "description": "Installs eslint-plugin-agent-code-guard, wires eslint.config.js and tsconfig strict flags, and applies safer-by-default principles to ongoing TypeScript work.",
       "version": "0.0.2",
       "author": {
         "name": "Tapan Chugh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.3] - 2026-04-18
+
+### Changed
+
+- **Package renamed to `eslint-plugin-agent-code-guard`.** Previously `eslint-plugin-safer-by-default`. The rename finishes the split started in commit 789a861, which separated the lint plugin (this repo, `chughtapan/agent-code-guard`) from the `/safer` Claude Code skills (`chughtapan/safer-by-default`). The rule namespace remains `safer-by-default/<rule>` because that is the philosophy family; the npm distribution name now matches the repo. Drift fixed in `package.json`, `src/utils/create-rule.ts` (doc-path comment), and `.claude-plugin/marketplace.json` (description).
+
 ## [0.0.2] - 2026-04-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-plugin-safer-by-default",
-  "version": "0.0.2",
+  "name": "eslint-plugin-agent-code-guard",
+  "version": "0.0.3",
   "description": "ESLint plugin that guards AI-agent-written TypeScript against common sloppy patterns: async/Promise/.then chains, bare catches, unsafe casts, raw SQL, manual enum casts, mocks in integration tests, and hardcoded secrets.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/utils/create-rule.ts
+++ b/src/utils/create-rule.ts
@@ -1,7 +1,7 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
 
 // Rule docs also ship inside the package at `docs/rules/<name>.md`, so agents
-// with filesystem access can read them from `node_modules/eslint-plugin-safer-by-default/docs/rules/`
+// with filesystem access can read them from `node_modules/eslint-plugin-agent-code-guard/docs/rules/`
 // even before the URLs resolve.
 const GITHUB_OWNER = "chughtapan";
 const GITHUB_REPO = "safer-by-default";


### PR DESCRIPTION
Closes #2.

## Changes
- `package.json` — name → `eslint-plugin-agent-code-guard`, version 0.0.2 → 0.0.3
- `CHANGELOG.md` — 0.0.3 entry
- `src/utils/create-rule.ts` — doc-comment path `node_modules/eslint-plugin-agent-code-guard/docs/rules/`
- `.claude-plugin/marketplace.json` — description install-command

## Grep verification
`grep -r 'eslint-plugin-safer-by-default' . --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git` before: 3 hits (package.json, src/utils/create-rule.ts, .claude-plugin/marketplace.json). After: 1 hit — the new CHANGELOG entry, which intentionally names the old id for the historical record.

README.md was already clean; no changes there.
src/index.ts uses `safer-by-default` as the rule namespace (intentional per README Name notes — philosophy family name, not npm package name). Not drift.

## Tests
`pnpm build && pnpm test` → 83/83 pass.

## Confidence
HIGH — mechanical rename, all three drift sites fixed, tests green.

## Concern
Issue acceptance specified `0.0.3 → 0.0.4`; actual baseline was `0.0.2`. Bumped one patch to `0.0.3` to preserve semver continuity. Flagging for review-senior.