### PR TITLE
[impl-senior] widen no-hardcoded-secrets: value-shape detection

### DIFF
--- a/docs/rules/no-hardcoded-secrets.md
+++ b/docs/rules/no-hardcoded-secrets.md
@@ -1,13 +1,36 @@
 # `safer-by-default/no-hardcoded-secrets`
 
-**What it flags:** String literals of 20+ characters assigned to names matching `apiKey` / `api_key` / `secret` / `token` / `password` / `authToken` (case-insensitive). Known placeholder values (`test`, `dummy`, `placeholder`, `your-key-here`, `example`, `sample`, `mock`) are allowed.
+**What it flags:** String literals that look like hardcoded secrets, caught by either of two triggers:
+
+1. **Name-gated:** 20+ character strings assigned to identifiers matching `apiKey` / `api_key` / `secret` / `token` / `password` / `authToken` (case-insensitive). Known placeholders (`test`, `dummy`, `placeholder`, `your-key-here`, `example`, `sample`, `mock`, `xxx…`) are allowed.
+2. **Value-shape:** strings matching a canonical secret shape, regardless of the LHS identifier. Renaming `const apiKey = 'sk_live_…'` to `const a = 'sk_live_…'` no longer bypasses the rule.
 
 **Why:** A hardcoded production secret in source is an incident waiting to happen — it gets pushed to git, crawled by a scraper, leaked to a log, or shared in a bug report. Even in test files, hardcoded keys are usually real keys someone "just used to get the test passing." Read secrets from the environment at runtime and fail loudly when they're missing.
+
+## Canonical shapes detected
+
+| Provider | Shape |
+| --- | --- |
+| Stripe | `/^(sk\|pk\|rk)_(live\|test)_[A-Za-z0-9]{16,}$/` |
+| AWS access key ID | `/^AKIA[0-9A-Z]{16}$/` |
+| AWS secret access key | `/^[A-Za-z0-9/+=]{40}$/` (note: collides with generic base64 — see options) |
+| JWT | `/^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/` |
+| GitHub PAT (classic) | `/^ghp_[A-Za-z0-9]{36}$/` |
+| GitHub PAT (fine-grained) | `/^github_pat_[A-Za-z0-9_]{82}$/` |
+| OpenAI API key | `/^sk-[A-Za-z0-9]{48}$/` |
+| OpenAI project key | `/^sk-proj-[A-Za-z0-9_-]{30,}$/` |
+| Anthropic API key | `/^sk-ant-[A-Za-z0-9_-]{30,}$/` |
 
 ## Before (flagged)
 
 ```ts
+// Name-gated trigger
 const apiKey = "sk_live_abc123xyz0987654321";
+
+// Value-shape trigger — rename bypass no longer works
+const a = "sk_live_abcdefghij1234567890";
+const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+const gh = "ghp_1234567890abcdefghijklmnopqrstuvwxAB";
 
 const client = new Service({
   apiKey: "sk_live_abcdef0123456789ghijkl",
@@ -44,6 +67,19 @@ export const env = Schema.decodeUnknownSync(Env)(process.env);
 Notes for agents:
 - If you need a value for a test, use a short obvious placeholder: `"test"`, `"dummy"`, `"placeholder"`, `"your-key-here"`. These are allowed by the rule.
 - For integration tests that need a real key, load it from the environment (same as production).
+
+## Options
+
+```jsonc
+{
+  "safer-by-default/no-hardcoded-secrets": [
+    "error",
+    { "detectEntropy": false }
+  ]
+}
+```
+
+- `detectEntropy` *(boolean, default `false`)* — opt-in high-entropy base64/hex detection for strings that do not match any canonical shape. **Not yet implemented** — the option is reserved so callers can turn it on once the detector lands. Entropy detection is noisy against hashes, checksums, and fixtures, so it will stay opt-in.
 
 ## Exceptions
 

--- a/src/rules/no-hardcoded-secrets.ts
+++ b/src/rules/no-hardcoded-secrets.ts
@@ -6,10 +6,43 @@ const SECRET_KEY_NAMES = /^(api[_-]?key|secret|token|password|auth[_-]?token)$/i
 const PLACEHOLDER_VALUES =
   /^(test|fake|dummy|placeholder|example|sample|mock|xxx+|\.{3,}|your[-_].*)$/i;
 
+// Canonical secret shapes. Matching any one of these is enough to flag a
+// string literal regardless of the identifier it is assigned to — closes the
+// rename-bypass hole that name-only gating left open (acg#10).
+const SECRET_SHAPES: ReadonlyArray<{ name: string; pattern: RegExp }> = [
+  { name: "Stripe key", pattern: /^(sk|pk|rk)_(live|test)_[A-Za-z0-9]{16,}$/ },
+  { name: "AWS access key ID", pattern: /^AKIA[0-9A-Z]{16}$/ },
+  // 40-char base64-ish; collides with generic base64 payloads but matches the
+  // canonical AWS secret access key shape.
+  { name: "AWS secret access key", pattern: /^[A-Za-z0-9/+=]{40}$/ },
+  {
+    name: "JWT",
+    pattern: /^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/,
+  },
+  {
+    name: "GitHub personal access token (classic)",
+    pattern: /^ghp_[A-Za-z0-9]{36}$/,
+  },
+  {
+    name: "GitHub personal access token (fine-grained)",
+    pattern: /^github_pat_[A-Za-z0-9_]{82}$/,
+  },
+  { name: "OpenAI API key", pattern: /^sk-[A-Za-z0-9]{48}$/ },
+  { name: "OpenAI project API key", pattern: /^sk-proj-[A-Za-z0-9_-]{30,}$/ },
+  { name: "Anthropic API key", pattern: /^sk-ant-[A-Za-z0-9_-]{30,}$/ },
+];
+
 function isSuspiciousSecretValue(value: string): boolean {
   if (value.length < 20) return false;
   if (PLACEHOLDER_VALUES.test(value)) return false;
   return /[a-zA-Z0-9_-]{20,}/.test(value);
+}
+
+function matchSecretShape(value: string): string | null {
+  for (const { name, pattern } of SECRET_SHAPES) {
+    if (pattern.test(value)) return name;
+  }
+  return null;
 }
 
 function keyName(
@@ -22,24 +55,46 @@ function keyName(
   return null;
 }
 
-export default createRule({
+type Options = [{ detectEntropy?: boolean }];
+type MessageIds = "hardcodedSecret";
+
+export default createRule<Options, MessageIds>({
   name: "no-hardcoded-secrets",
   meta: {
     type: "problem",
     docs: {
       description:
-        "Flag hardcoded secret-looking string literals assigned to names like apiKey, token, secret, password. Use environment variables instead.",
+        "Flag hardcoded secret-looking string literals — either assigned to a secret-looking name, or matching a canonical secret shape (Stripe, AWS, JWT, GitHub, OpenAI, Anthropic). Use environment variables instead.",
     },
     messages: {
       hardcodedSecret:
         "Hardcoded {{field}} literal — use process.env.* (or your config loader) instead",
     },
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          detectEntropy: {
+            type: "boolean",
+            description:
+              "Opt-in: flag high-entropy base64/hex strings that do not match a canonical shape. Off by default — noisy on checksums, hashes, and fixtures.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     fixable: undefined,
     hasSuggestions: false,
   },
-  defaultOptions: [],
-  create(context) {
+  defaultOptions: [{ detectEntropy: false }],
+  create(context, [options]) {
+    // TODO(acg#10): implement high-entropy base64/hex detection when
+    // `detectEntropy` is true. Stub only — option reserved so callers can opt
+    // in once the detector lands; noisy on hashes/checksums, hence default off.
+    void options.detectEntropy;
+
+    const handledLiterals = new WeakSet<TSESTree.Node>();
+
     function checkLiteralFor(
       field: string,
       valueNode: TSESTree.Node,
@@ -51,6 +106,7 @@ export default createRule({
       ) {
         return;
       }
+      handledLiterals.add(valueNode);
       if (!isSuspiciousSecretValue(valueNode.value)) return;
       context.report({
         node: reportNode,
@@ -84,6 +140,17 @@ export default createRule({
         }
         if (!field || !SECRET_KEY_NAMES.test(field)) return;
         checkLiteralFor(field, node.right, node);
+      },
+      Literal(node) {
+        if (handledLiterals.has(node)) return;
+        if (typeof node.value !== "string") return;
+        const shape = matchSecretShape(node.value);
+        if (!shape) return;
+        context.report({
+          node,
+          messageId: "hardcodedSecret",
+          data: { field: shape },
+        });
       },
     };
   },

--- a/tests/no-hardcoded-secrets.test.ts
+++ b/tests/no-hardcoded-secrets.test.ts
@@ -19,12 +19,20 @@ ruleTester.run("no-hardcoded-secrets", rule, {
     { code: "const apiKey = 'test';" },
     { code: "const apiKey = process.env.API_KEY;" },
     { code: "const config = { apiKey: 'placeholder' };" },
-    { code: "const notSecret = 'sk_live_abcdefghijklmnop';" },
+    // Short value under a non-secret name — no shape, no length trip.
+    { code: "const x = 'short';" },
+    // Name looks secret-adjacent but value has spaces so no shape matches.
+    { code: "const ghp = 'not a real ghp';" },
+    // Long-ish text that happens not to match any canonical shape.
+    {
+      code: "const message = 'this is a normal sentence that is long enough';",
+    },
     {
       code: "// eslint-disable-next-line @rule-tester/no-hardcoded-secrets -- suppression test\nconst apiKey = 'sk_live_abc123xyz0987654321';",
     },
   ],
   invalid: [
+    // --- Name-gated cases (prior behavior, preserved) ---
     {
       code: "const apiKey = 'sk_live_abc123xyz0987654321';",
       errors: [{ messageId: "hardcodedSecret" }],
@@ -43,6 +51,52 @@ ruleTester.run("no-hardcoded-secrets", rule, {
     },
     {
       code: "const secret = 'Bearer AAAAAAAAAA1234567890abcdef';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // --- Value-shape cases: non-matching LHS name, rule still fires ---
+    // Stripe
+    {
+      code: "const a = 'sk_live_abcdefghij1234567890';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // AWS access key ID
+    {
+      code: "const a = 'AKIAIOSFODNN7EXAMPLE';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // AWS secret access key (40-char base64-shaped)
+    {
+      code: "const a = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // JWT
+    {
+      code: "const a = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // GitHub PAT classic (ghp_ + 36 alphanumerics)
+    {
+      code: "const a = 'ghp_1234567890abcdefghijklmnopqrstuvwxAB';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // GitHub PAT fine-grained (github_pat_ + 82 chars of [A-Za-z0-9_])
+    {
+      code: "const a = 'github_pat_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // OpenAI (sk- + 48 alphanumerics)
+    {
+      code: "const a = 'sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // OpenAI project (sk-proj- + 30+ chars of [A-Za-z0-9_-])
+    {
+      code: "const a = 'sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';",
+      errors: [{ messageId: "hardcodedSecret" }],
+    },
+    // Anthropic (sk-ant- + 30+ chars of [A-Za-z0-9_-])
+    {
+      code: "const a = 'sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';",
       errors: [{ messageId: "hardcodedSecret" }],
     },
   ],

--- a/tests/property/rule-correctness.test.ts
+++ b/tests/property/rule-correctness.test.ts
@@ -209,12 +209,11 @@ describe("property: rule correctness", () => {
     "safer-by-default/record-cast": "r",
     "safer-by-default/no-raw-sql": "db",
     "safer-by-default/no-manual-enum-cast": "s",
-    // Name-gated: rule keys on the LHS identifier matching SECRET_KEY_NAMES.
-    // Rename to a non-matching ident is a true negative by design — skip the
-    // rename mutation so Property 2 tests the invariant the rule actually
-    // promises. Senior follow-up (acg#10) tracks whether value-shape detection
-    // should complement name-based triggering.
-    "safer-by-default/no-hardcoded-secrets": "",
+    // Rename exercises the value-shape detector added in acg#10: the seed's
+    // LHS is `apiKey`, mutation renames it to a random non-secret-looking
+    // ident, and the rule still fires because `sk_live_...` matches the
+    // Stripe canonical shape regex.
+    "safer-by-default/no-hardcoded-secrets": "apiKey",
     "safer-by-default/no-raw-throw-new-error": "",
     "safer-by-default/no-test-skip-only": "",
     "safer-by-default/no-coverage-threshold-gate": "",


### PR DESCRIPTION
Closes #10
Surfaced by fast-check Property 2 in #8.

## What changed
The `no-hardcoded-secrets` rule now fires when **either** the LHS identifier matches `SECRET_KEY_NAMES` (existing behavior) **or** the string literal value matches a canonical secret shape. Renaming `const apiKey = 'sk_live_...'` to `const a = 'sk_live_...'` no longer bypasses the rule.

A new rule option `detectEntropy` is reserved (default `false`) for future high-entropy base64/hex detection. The detector itself is **not** implemented in this PR — option stub only, so callers can opt in without a schema break later.

## Plan anchors

| Change | Anchor (issue #10) |
| --- | --- |
| Add `SECRET_SHAPES` table + `matchSecretShape` helper | "Detect by value shape in ADDITION to identifier name" |
| New `Literal` visitor with `WeakSet` dedup against name-gated reports | "Rule fires if EITHER the identifier regex matches OR the value matches a canonical secret shape" |
| Add `detectEntropy` rule option, stub + TODO | "Generic high-entropy base64/hex ≥24 chars … opt-in via rule option; off by default" |
| +9 invalid tests (one per canonical shape) + 3 valid negatives | "tests cover each new shape + keeps existing identifier-name coverage" |
| Docs: both triggers, shape table, option | "Rule widened" |
| Remove name-gated opt-out in `IDENTS_BY_SEED` | PR #8 follow-up: Property 2 passes on its own |

## Canonical shapes detected

- Stripe: `/^(sk|pk|rk)_(live|test)_[A-Za-z0-9]{16,}$/`
- AWS access key ID: `/^AKIA[0-9A-Z]{16}$/`
- AWS secret access key: `/^[A-Za-z0-9/+=]{40}$/` *(collides with generic base64; kept in default set but flagged in docs — if noisy in practice, follow-up moves behind an option)*
- JWT: `/^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/`
- GitHub PAT classic: `/^ghp_[A-Za-z0-9]{36}$/`
- GitHub PAT fine-grained: `/^github_pat_[A-Za-z0-9_]{82}$/`
- OpenAI: `/^sk-[A-Za-z0-9]{48}$/`
- OpenAI project: `/^sk-proj-[A-Za-z0-9_-]{30,}$/`
- Anthropic: `/^sk-ant-[A-Za-z0-9_-]{30,}$/`

## Rename-bypass closure

`tests/property/rule-correctness.test.ts` previously carried `IDENTS_BY_SEED["safer-by-default/no-hardcoded-secrets"] = ""` — an explicit skip-rename opt-out with a comment pointing at this issue. The entry is now `"apiKey"`, so Property 2 actively renames the LHS to a random non-secret ident on every run; the rule continues to fire because the Stripe shape regex matches the value. Property 2 passes on its own, 20 fast-check iterations × 11 seeds.

## Scope
- Modules touched: `src/rules/no-hardcoded-secrets.ts`, `tests/no-hardcoded-secrets.test.ts`, `docs/rules/no-hardcoded-secrets.md`, `tests/property/rule-correctness.test.ts`.
- New modules: 0
- New public signatures outside the plan: 0 (rule option added is per-rule schema, not package surface)
- New deps: 0

## Tests
- 11 existing `no-hardcoded-secrets` cases → 21 (+9 invalid shape cases, +3 valid negatives; -1 valid case moved to invalid because its value now matches the Stripe shape).
- Property 2 for `no-hardcoded-secrets` now exercises rename + value-shape path.
- `pnpm test`: 157 passed (was 146).
- `pnpm build` (tsc): clean.

## Out of scope
- Entropy-based detection (option stub only, TODO).
- Scanning non-literal values (template literals, call expressions, env vars).

## Confidence
MED — false-positive risk on `AWS secret access key` shape (40-char base64-ish). Default-on; docs call it out. If noise surfaces, follow-up gates it behind an option.