### PR TITLE
[impl-senior] test-hardening: no-raw-sql mutation score ≥80%

### DIFF
--- a/tests/no-raw-sql.test.ts
+++ b/tests/no-raw-sql.test.ts
@@ -22,6 +22,16 @@ ruleTester.run("no-raw-sql", rule, {
     {
       code: "// eslint-disable-next-line @rule-tester/no-raw-sql -- suppression test\ndb.query('SELECT * FROM users');",
     },
+    // Non-.query() method calls are not flagged even with SQL content
+    { code: "db.exec(`SELECT * FROM users`);" },
+    // Bracket-notation .query() is not flagged — only dot-notation .query() calls are in scope
+    { code: "db['query'](`SELECT * FROM users`);" },
+    // Pure-interpolation template with no static SQL keyword in the head is not flagged
+    { code: "client.query(`${foo}`);" },
+    // Tagged template with an unknown tag (not sql/SQL) is not flagged
+    { code: "db.query(myTag`SELECT * FROM users`);" },
+    // Call with no arguments is not flagged
+    { code: "db.query();" },
   ],
   invalid: [
     {
@@ -42,6 +52,16 @@ ruleTester.run("no-raw-sql", rule, {
     },
     {
       code: "conn.query('DROP TABLE temp');",
+      errors: [{ messageId: "rawSql" }],
+    },
+    // Tagged template with sql tag is flagged as raw SQL
+    {
+      code: "db.query(sql`SELECT * FROM users`);",
+      errors: [{ messageId: "rawSql" }],
+    },
+    // Tagged template with SQL tag (uppercase) is also flagged
+    {
+      code: "db.query(SQL`INSERT INTO logs VALUES ($1)`);",
       errors: [{ messageId: "rawSql" }],
     },
   ],


### PR DESCRIPTION
Closes #20

## What changed

Adds 7 new test cases (5 valid, 2 invalid) to `tests/no-raw-sql.test.ts` targeting surviving and NoCoverage mutant clusters identified in Stryker run on `src/rules/no-raw-sql.ts`. Mutation score raised from **40.63% → 93.75%** (≥80% goal met; project break threshold is 50).

## Plan anchors

| Change | Issue #20 anchor |
|---|---|
| Valid: `db.exec(\`SELECT...\`)` | §"Lines 51–54 — `prop.name !== 'query'` guard survives" |
| Valid: `db['query'](\`SELECT...\`)` | §"Lines 51–54 — `callee.computed` guard survives" |
| Valid: `client.query(\`\${foo}\`)` | §"Line 12 — `quasis[0]?.value.raw ?? ''` fallback" |
| Valid: `db.query(myTag\`SELECT...\`)` | §"Lines 18–24 — TaggedTemplateExpression block NoCoverage" |
| Valid: `db.query()` | §"Line 58 — `!first` guard" (identified during run, not in issue rubric) |
| Invalid: `db.query(sql\`SELECT...\`)` | §"Lines 18–24 — No test calls `.query(sql\`…\`)` tagged-template form" |
| Invalid: `db.query(SQL\`INSERT...\`)` | §"Lines 18–24 — No test calls `.query(SQL\`…\`)` tagged-template form" |

## Scope

- Modules touched: `tests/no-raw-sql.test.ts`
- Tier (safer-diff-scope not installed; manual assessment): junior-to-senior (single test file, 20 LOC added)
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Tests

- Mutation score: 93.75% (26/28 scored mutants killed; 2 surviving are un-killable — `quasis[0]?.` optional chain and `?? ""` fallback, both require `quasis[0]` to be undefined which never happens in valid AST)
- All 194 tests pass including property tests

## Simplify pass

- Ran `/simplify`; applied findings: removed redundant `db.execute()` case (same mutant as `db.exec()`), rewrote comments to remove stale line-number references.

## Confidence

HIGH — Stryker run confirms 93.75%; surviving 2 mutants are structural impossibilities in valid ESLint AST, not reachable by any test.

---
`/safer:review-senior` required before merge.