### PR TITLE
[impl-senior] promise-type: mark 6 equivalent mutants; 75% → 100% mutation score

### DIFF
--- a/src/rules/promise-type.ts
+++ b/src/rules/promise-type.ts
@@ -14,10 +14,12 @@ function isReturnTypeAnnotation(
   node: TSESTree.TSTypeReference,
 ): boolean {
   const annotation = node.parent;
+  // Stryker disable next-line ConditionalExpression,BlockStatement -- equivalent: if annotation.type !== TSTypeAnnotation, owner falls to switch default (returns false) in all reachable TypeScript AST inputs
   if (!annotation || annotation.type !== AST_NODE_TYPES.TSTypeAnnotation) {
     return false;
   }
   const owner = annotation.parent;
+  // Stryker disable next-line ConditionalExpression,BooleanLiteral -- equivalent: annotation.parent is never null in ESLint AST traversal
   if (!owner) return false;
 
   switch (owner.type) {
@@ -28,6 +30,7 @@ function isReturnTypeAnnotation(
     case AST_NODE_TYPES.TSMethodSignature:
     case AST_NODE_TYPES.TSDeclareFunction:
     case AST_NODE_TYPES.TSEmptyBodyFunctionExpression:
+      // Stryker disable next-line ConditionalExpression -- equivalent: when owner is a function-type node, owner.returnType === annotation is a structural tautology of the @typescript-eslint AST
       return owner.returnType === annotation;
     default:
       return false;

--- a/tests/promise-type.test.ts
+++ b/tests/promise-type.test.ts
@@ -40,12 +40,20 @@ ruleTester.run("promise-type", rule, {
     // TSTypeAnnotation. Exercises the annotation.type !== TSTypeAnnotation branch (line 17).
     { code: "function f(): Promise<number> | string { return ''; }" },
     { code: "const f = (): Promise<number> | null => null;" },
+    // Promise nested inside a generic return type — annotation is TSTypeParameterInstantiation,
+    // not TSTypeAnnotation. Exercises annotation.type !== TSTypeAnnotation branch (line 17).
+    { code: "function f(): Array<Promise<number>> { return []; }" },
+    // Promise as element type of array return — annotation is TSArrayType.
+    { code: "function f(): Promise<number>[] { return []; }" },
+    // Promise in object-literal return type property — annotation is TSTypeAnnotation but
+    // owner is TSPropertySignature (not in the function-owner switch cases).
+    { code: "function f(): { x: Promise<number> } { return { x: Promise.resolve(1) }; }" },
     // Function with no return annotation — Promise only in body, no TSTypeReference visited
     // for the function's return annotation at all.
     { code: "function f() { return Promise.resolve(1); }" },
     // Suppression test
     {
-      code: "// eslint-disable-next-line @rule-tester/promise-type -- suppression test (real prefix in production is `safer-by-default/promise-type`)\nfunction suppressed(): Promise<number> { return Promise.resolve(1); }",
+      code: "// eslint-disable-next-line @rule-tester/promise-type -- suppression test (real prefix in production is `agent-code-guard/promise-type`)\nfunction suppressed(): Promise<number> { return Promise.resolve(1); }",
     },
     // Promise nested in an intersection in return position — not direct annotation
     { code: "function f(): Promise<number> & { tag: string } { return Promise.resolve(1) as any; }" },


### PR DESCRIPTION
Closes #31

## What changed

Six surviving mutants from the premature-merged PR #27 were identified as **structurally equivalent** — no TypeScript code pattern can produce AST inputs that distinguish their behavior from the original. Three `// Stryker disable next-line` metadata comments (no logic change) annotate these dead branches. Three additional valid test cases document the boundary conditions explicitly.

## Plan anchors

| Change | Issue #31 anchor |
|---|---|
| `// Stryker disable next-line ConditionalExpression,BlockStatement` — line 17 | Issue §1–3: annotation missing / not TSTypeAnnotation / guard-reject fallthrough |
| `// Stryker disable next-line ConditionalExpression,BooleanLiteral` — line 21 | Issue §4–5: unresolvable owner / NoCoverage return false |
| `// Stryker disable next-line ConditionalExpression` — line 31 | Issue §6: returnType === annotation structural tautology |
| Valid: `function f(): Array<Promise<number>> { return []; }` | Documents TSTypeParameterInstantiation fallthrough path |
| Valid: `function f(): Promise<number>[] { return []; }` | Documents TSArrayType annotation path |
| Valid: `function f(): { x: Promise<number> } { ... }` | Documents TSPropertySignature owner (switch default) |

## Equivalence analysis

All 6 surviving mutants are equivalent. Here is why each is unkillable by unit tests:

**Lines 17:7, 17:22, 17:75 (ConditionalExpression / BlockStatement):**
When `annotation.type !== TSTypeAnnotation`, the fallthrough path computes `owner = annotation.parent`. In all reachable @typescript-eslint AST inputs, `annotation.parent` is never one of the 7 function-owner types in the switch (it's always something like TSUnionType, TSArrayType, or TSTypeAliasDeclaration whose parent is a TSTypeAnnotation — hitting switch `default → return false`). Original and mutant produce identical results.

**Lines 21:7, 21:22 (ConditionalExpression / BooleanLiteral):**
`annotation.parent` (`owner`) is never null during ESLint traversal — every node except the root (Program) has a parent, and TSTypeAnnotation can never be the root. The `!owner` guard is a defensive dead branch.

**Line 31:14 (ConditionalExpression):**
When `owner` IS one of the 7 function-type nodes (switch match), `owner.returnType === annotation` is always true by definition: the only field on those AST nodes that could parent a TSTypeAnnotation is `returnType`, and ESLint's traversal sets parent pointers to reflect that exact relationship. The equality check is a structural tautology.

**Resolution:** `// Stryker disable next-line` is the standard Stryker mechanism for annotating equivalent mutants. These are metadata comments; the rule logic is unchanged.

## Scope

- Files touched: `src/rules/promise-type.ts` (metadata comments only), `tests/promise-type.test.ts` (+3 valid cases)
- New modules: 0
- New public signatures: 0
- New deps: 0

## Stryker output

```
All files        | 100.00 |  100.00 |       17 |         0 |          0 |        0 |       16 |
 promise-type.ts | 100.00 |  100.00 |       17 |         0 |          0 |        0 |       16 |
```

17 killed, 0 survived, 0 no-coverage, 16 compile-errors (excluded from score), **100% mutation score**.

## Tests

- 3 new valid test cases: `Array<Promise<number>>` (TSTypeParameterInstantiation path), `Promise<number>[]` (TSArrayType path), `{ x: Promise<number> }` (TSPropertySignature owner → switch default path)
- All 171 tests pass

## Simplify pass

One redundant phrase removed from test comment ("Confirmed equivalent to the union case: fallthrough owner is non-function-type" restated what the adjacent line said). No other findings.

## Confidence

HIGH — Stryker output pasted above shows 100% with 0 survived. Equivalence analysis verified by exhaustive structural reasoning over all possible @typescript-eslint v8 AST inputs. `/safer:review-senior` and `/safer:verify` mandatory before merge — do NOT merge without verify run.

---
/safer:review-senior is mandatory before merge.
/safer:verify is mandatory before merge (per issue #31 explicit gate).