### PR TITLE
[impl-junior] dogfood: acg self-lints via eslint-plugin-agent-code-guard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,45 @@
+import guard from "eslint-plugin-agent-code-guard";
+import tsParser from "@typescript-eslint/parser";
+
+export default [
+  // Block 1: plugin source.
+  {
+    files: ["src/**/*.ts"],
+    ignores: ["**/*.test.ts", "**/*.spec.ts", "dist/**", "node_modules/**"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+    },
+    plugins: {
+      "agent-code-guard": guard,
+    },
+    rules: {
+      ...guard.configs.recommended.rules,
+    },
+  },
+
+  // Block 2: unit tests.
+  {
+    files: ["tests/**/*.ts", "**/*.test.ts", "**/*.spec.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+    },
+    plugins: {
+      "agent-code-guard": guard,
+    },
+    rules: {
+      ...guard.configs.recommended.rules,
+      "agent-code-guard/async-keyword": "off",
+      "agent-code-guard/no-hardcoded-assertion-literals": "off",
+    },
+  },
+
+  {
+    ignores: [
+      "dist/**",
+      "node_modules/**",
+      "coverage/**",
+    ],
+  },
+];

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
+    "lint": "eslint .",
     "test": "vitest run",
     "mutation": "stryker run",
     "prepublishOnly": "pnpm build && pnpm test"
@@ -58,6 +59,7 @@
     "@typescript-eslint/parser": "^8.0.0",
     "@typescript-eslint/rule-tester": "^8.0.0",
     "eslint": "^9.0.0",
+    "eslint-plugin-agent-code-guard": "^0.0.2",
     "fast-check": "^4.7.0",
     "typescript": "^5.4.0",
     "vitest": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       eslint:
         specifier: ^9.0.0
         version: 9.39.4
+      eslint-plugin-agent-code-guard:
+        specifier: ^0.0.2
+        version: 0.0.2(eslint@9.39.4)(typescript@5.9.3)
       fast-check:
         specifier: ^4.7.0
         version: 4.7.0
@@ -980,6 +983,12 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-plugin-agent-code-guard@0.0.2:
+    resolution: {integrity: sha512-tMsSmZRy2LGEDsRwDVNI3ejDPga30UcWDfLPwf7UpJSwa5qljskMcneAZxnDWbt4ASzt8hZVCRT2Jkm7hl30gA==}
+    peerDependencies:
+      eslint: '>=9'
+      typescript: '>=5'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -2557,6 +2566,14 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-agent-code-guard@0.0.2(eslint@9.39.4)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-scope@8.4.0:
     dependencies:


### PR DESCRIPTION
Closes #33

## What changed
Added eslint-plugin-agent-code-guard to devDependencies, created eslint.config.js wiring the recommended preset to src/**/*.ts and the test carve-outs to tests/**/*.ts, added lint script to package.json.

## Scope
- Module: repo root (eslint config)
- Tier (from safer-diff-scope): junior
- New exported signatures: none
- New deps: eslint-plugin-agent-code-guard (0.0.2, as specified in issue)

## Baseline
- `pnpm lint` runs without config errors
- Violation count: 0 files with violations
- No follow-up cleanup needed

## Confidence
HIGH — config successfully wired, lint runs cleanly, repo dogfoods its own plugin