### PR TITLE
[impl-junior] bench: harness + baseline

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,51 @@
+# bench
+
+Measures `eslint-plugin-agent-code-guard` lint time on synthetic and real
+projects. Used to validate the layered performance changes in
+`/home/tapanc/.claude/plans/come-up-with-a-squishy-crown.md`.
+
+## Run
+
+```bash
+pnpm build                              # bench reads dist/
+pnpm tsx bench/generate-fixture.ts      # writes bench/fixtures/{small,medium,large}/
+pnpm bench                              # times all targets vs baseline.json
+pnpm bench --only large                 # one target
+pnpm bench --write-baseline             # overwrite baseline.json with this run
+```
+
+Targets:
+
+- `small` — 50 generated files
+- `medium` — 500 generated files
+- `large` — 1,500 generated files
+- `xlarge` — 5,000 generated files (opt-in; pre-optimization warm time is several
+  minutes — generate via `pnpm bench:generate xlarge` only when needed)
+- `self` — this repo's own `src/`
+
+The pre-optimization architecture analyzer is O(F·D) in its per-file scan
+(see plan), which is the cost this bench is measuring. `xlarge` is excluded
+from the default `pnpm bench` baseline because a single cold lint takes
+~10 min on pre-Phase-1 code; revisit after Phase 1.
+
+Each target spawns N subprocesses (default 3). Each subprocess runs ESLint
+M times in-process (default 4). The first lint per subprocess is "cold"
+(empty architecture cache); the rest are "warm". Output shows the median
+cold and warm times across all subprocesses, plus the diagnostic count
+and a hash of the sorted diagnostic set (parity check).
+
+## Baseline
+
+`bench/baselines/baseline.json` is committed. `pnpm bench` diffs the
+current run against it and prints the delta. Update with `--write-baseline`
+after each performance change in the plan, then commit.
+
+`bench/baselines/RESULTS.md` (added in Phase 4) shows the cumulative
+impact across phases.
+
+## Fixture parity
+
+The diagnosticsHash field in each run is a `sha256` of the sorted
+diagnostic set. Identical hashes mean the optimization did not change
+what the analyzer reports. Hash drift between phases is a regression
+unless explicitly justified.

--- a/bench/baselines/baseline.json
+++ b/bench/baselines/baseline.json
@@ -1,0 +1,54 @@
+{
+  "capturedAt": "2026-05-12T05:44:20.828Z",
+  "node": "v24.14.1",
+  "results": [
+    {
+      "target": "small",
+      "cold_ms_median": 5197.6146645,
+      "cold_ms_min": 5171.392666,
+      "cold_ms_max": 5223.836663,
+      "warm_ms_median": 334.30556799999977,
+      "warm_ms_min": 292.99201600000015,
+      "warm_ms_max": 349.6399019999999,
+      "diagnostics": 136,
+      "diagnosticsHash": "481cc6b97d3291de",
+      "peakRssMB": 527.8
+    },
+    {
+      "target": "medium",
+      "cold_ms_median": 9199.004575,
+      "cold_ms_min": 8382.031920000001,
+      "cold_ms_max": 10015.97723,
+      "warm_ms_median": 3924.126106499999,
+      "warm_ms_min": 2654.3567380000004,
+      "warm_ms_max": 4056.2213659999998,
+      "diagnostics": 1383,
+      "diagnosticsHash": "e3ee14c33936a36b",
+      "peakRssMB": 724.9
+    },
+    {
+      "target": "large",
+      "cold_ms_median": 22380.448771,
+      "cold_ms_min": 22294.643518,
+      "cold_ms_max": 22466.254023999998,
+      "warm_ms_median": 16662.772888,
+      "warm_ms_min": 16011.021151,
+      "warm_ms_max": 17482.499373,
+      "diagnostics": 4040,
+      "diagnosticsHash": "84a1d7209b8de6cc",
+      "peakRssMB": 1151.2
+    },
+    {
+      "target": "self",
+      "cold_ms_median": 19684.929926,
+      "cold_ms_min": 18410.917968,
+      "cold_ms_max": 20958.941884,
+      "warm_ms_median": 11192.6963455,
+      "warm_ms_min": 11162.571767999998,
+      "warm_ms_max": 12881.726341000001,
+      "diagnostics": 0,
+      "diagnosticsHash": "e3b0c44298fc1c14",
+      "peakRssMB": 1468.9
+    }
+  ]
+}

--- a/bench/fixtures/.gitignore
+++ b/bench/fixtures/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/bench/generate-fixture.ts
+++ b/bench/generate-fixture.ts
@@ -1,0 +1,227 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..");
+const FIXTURES_ROOT = path.join(HERE, "fixtures");
+
+const SIZES = {
+  small: { files: 50, filesPerFolder: 10 },
+  medium: { files: 500, filesPerFolder: 15 },
+  large: { files: 1_500, filesPerFolder: 20 },
+  xlarge: { files: 5_000, filesPerFolder: 25 },
+} as const;
+
+type SizeName = keyof typeof SIZES;
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function pad(n: number, width: number): string {
+  return String(n).padStart(width, "0");
+}
+
+function writeFile(absPath: string, content: string): void {
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content);
+}
+
+interface FileSpec {
+  readonly relPath: string;
+  readonly imports: readonly string[];
+  readonly exportNames: readonly string[];
+}
+
+function planFiles(size: SizeName): readonly FileSpec[] {
+  const { files, filesPerFolder } = SIZES[size];
+  const folderCount = Math.max(1, Math.ceil(files / filesPerFolder));
+  const rng = mulberry32(1729 + files);
+  const specs: FileSpec[] = [];
+
+  for (let i = 0; i < files; i++) {
+    const folderIdx = Math.floor(i / filesPerFolder);
+    const fileIdx = i % filesPerFolder;
+    const folder = `domain${pad(folderIdx, 3)}`;
+    const baseName = `mod${pad(fileIdx, 3)}`;
+    const relPath = `src/${folder}/${baseName}.ts`;
+
+    const exportNames = [`fn${pad(i, 4)}`];
+
+    const imports: string[] = [];
+    if (i > 0 && rng() < 0.6) {
+      const prev = specs[Math.floor(rng() * i)];
+      const importPath = path
+        .relative(path.dirname(relPath), prev.relPath)
+        .replace(/\.ts$/, ".js");
+      const importSpec = importPath.startsWith(".")
+        ? importPath
+        : `./${importPath}`;
+      imports.push(`import { ${prev.exportNames[0]} } from "${importSpec}";`);
+    }
+
+    specs.push({ relPath, imports, exportNames });
+  }
+
+  for (let folderIdx = 0; folderIdx < folderCount; folderIdx++) {
+    const folder = `domain${pad(folderIdx, 3)}`;
+    const folderFiles = specs.filter((s) => s.relPath.startsWith(`src/${folder}/`));
+    if (folderFiles.length === 0) continue;
+    const indexImports = folderFiles
+      .map((spec) => {
+        const base = path.basename(spec.relPath, ".ts");
+        return `export { ${spec.exportNames[0]} } from "./${base}.js";`;
+      })
+      .join("\n");
+    specs.push({
+      relPath: `src/${folder}/index.ts`,
+      imports: [],
+      exportNames: [],
+    } as FileSpec);
+    fileBodyOverride.set(`src/${folder}/index.ts`, indexImports + "\n");
+  }
+
+  return specs;
+}
+
+const fileBodyOverride = new Map<string, string>();
+
+function renderFile(spec: FileSpec): string {
+  const override = fileBodyOverride.get(spec.relPath);
+  if (override !== undefined) return override;
+  const importsBlock = spec.imports.length > 0 ? spec.imports.join("\n") + "\n\n" : "";
+  const bodyLines = spec.exportNames.map(
+    (name) => `export function ${name}(): number {\n  return ${name.length};\n}`,
+  );
+  return `${importsBlock}${bodyLines.join("\n\n")}\n`;
+}
+
+function rmrf(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function generateFixture(size: SizeName): string {
+  const fixtureDir = path.join(FIXTURES_ROOT, size);
+  rmrf(fixtureDir);
+  fs.mkdirSync(fixtureDir, { recursive: true });
+
+  const specs = planFiles(size);
+
+  const indexExports = specs
+    .filter((s) => s.relPath.endsWith("/index.ts") && s.relPath !== "src/index.ts")
+    .map((s) => {
+      const folder = path.basename(path.dirname(s.relPath));
+      return `export * from "./${folder}/index.js";`;
+    })
+    .join("\n");
+  writeFile(path.join(fixtureDir, "src/index.ts"), indexExports + "\n");
+
+  for (const spec of specs) {
+    writeFile(path.join(fixtureDir, spec.relPath), renderFile(spec));
+  }
+
+  writeFile(
+    path.join(fixtureDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          strict: true,
+          esModuleInterop: true,
+          skipLibCheck: true,
+          declaration: false,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src/**/*.ts"],
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  writeFile(
+    path.join(fixtureDir, "package.json"),
+    JSON.stringify(
+      {
+        name: `bench-fixture-${size}`,
+        version: "0.0.0",
+        private: true,
+        type: "module",
+        main: "src/index.ts",
+        exports: { ".": "./src/index.ts" },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  const pluginEntry = path.relative(fixtureDir, path.join(REPO_ROOT, "dist/index.js"));
+  writeFile(
+    path.join(fixtureDir, "eslint.config.js"),
+    `import guard from "${pluginEntry}";
+import tsParser from "@typescript-eslint/parser";
+
+const ARCHITECTURE_OPTIONS = {
+  projectRoot: import.meta.dirname,
+  tsconfigPath: "tsconfig.json",
+};
+
+const ARCHITECTURE_RULE_IDS = Object.keys(guard.configs.architecture.rules);
+
+const recommendedRules = {
+  ...guard.configs.recommended.rules,
+  ...Object.fromEntries(
+    ARCHITECTURE_RULE_IDS.map((id) => [
+      id,
+      [guard.configs.recommended.rules[id] ?? "error", ARCHITECTURE_OPTIONS],
+    ]),
+  ),
+};
+
+export default [
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+    },
+    plugins: guard.configs.recommended.plugins,
+    settings: guard.configs.recommended.settings,
+    rules: recommendedRules,
+  },
+  { ignores: ["node_modules/**", "dist/**"] },
+];
+`,
+  );
+
+  return fixtureDir;
+}
+
+function main(): void {
+  const arg = process.argv[2];
+  const targets: readonly SizeName[] = arg
+    ? [arg as SizeName]
+    : (Object.keys(SIZES) as SizeName[]);
+  for (const size of targets) {
+    if (!(size in SIZES)) {
+      console.error(`unknown size: ${size}. valid: ${Object.keys(SIZES).join(", ")}`);
+      process.exit(1);
+    }
+    const dir = generateFixture(size);
+    const fileCount = SIZES[size].files;
+    console.log(`generated ${size}: ${fileCount} files at ${path.relative(REPO_ROOT, dir)}`);
+  }
+}
+
+main();

--- a/bench/lint-bench.ts
+++ b/bench/lint-bench.ts
@@ -1,0 +1,227 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..");
+const FIXTURES_ROOT = path.join(HERE, "fixtures");
+const BASELINE_PATH = path.join(HERE, "baselines/baseline.json");
+const TSX_BIN = path.join(REPO_ROOT, "node_modules/.bin/tsx");
+
+interface Target {
+  readonly name: string;
+  readonly cwd: string;
+  readonly patterns: string;
+}
+
+interface BenchOptions {
+  readonly subprocesses: number;
+  readonly repeats: number;
+  readonly writeBaseline: boolean;
+  readonly only: string | null;
+}
+
+interface SubprocessResult {
+  readonly cold_ms: number;
+  readonly warm_ms: readonly number[];
+  readonly diagnostics: number;
+  readonly diagnosticsHash: string;
+  readonly peakRssBytes: number;
+}
+
+interface TargetResult {
+  readonly target: string;
+  readonly cold_ms_median: number;
+  readonly cold_ms_min: number;
+  readonly cold_ms_max: number;
+  readonly warm_ms_median: number;
+  readonly warm_ms_min: number;
+  readonly warm_ms_max: number;
+  readonly diagnostics: number;
+  readonly diagnosticsHash: string;
+  readonly peakRssMB: number;
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function fmt(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${ms.toFixed(0)}ms`;
+}
+
+function parseOptions(argv: readonly string[]): BenchOptions {
+  let subprocesses = 3;
+  let repeats = 4;
+  let writeBaseline = false;
+  let only: string | null = null;
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    switch (flag) {
+      case "--write-baseline":
+        writeBaseline = true;
+        break;
+      case "--subprocesses":
+        subprocesses = Number.parseInt(argv[++i], 10);
+        break;
+      case "--repeats":
+        repeats = Number.parseInt(argv[++i], 10);
+        break;
+      case "--only":
+        only = argv[++i];
+        break;
+      default:
+        throw new Error(`unknown flag: ${flag}`);
+    }
+  }
+  return { subprocesses, repeats, writeBaseline, only };
+}
+
+function collectTargets(only: string | null): Target[] {
+  const all: Target[] = [];
+  for (const size of ["small", "medium", "large", "xlarge"] as const) {
+    const dir = path.join(FIXTURES_ROOT, size);
+    if (!fs.existsSync(dir)) continue;
+    all.push({ name: size, cwd: dir, patterns: "src/**/*.ts" });
+  }
+  all.push({ name: "self", cwd: REPO_ROOT, patterns: "src/**/*.ts" });
+  return only === null ? all : all.filter((t) => t.name === only);
+}
+
+function runOnce(target: Target, repeats: number): SubprocessResult {
+  const lintOnePath = path.join(HERE, "lint-one.ts");
+  const result = spawnSync(
+    TSX_BIN,
+    [
+      lintOnePath,
+      "--cwd",
+      target.cwd,
+      "--patterns",
+      target.patterns,
+      "--repeats",
+      String(repeats),
+    ],
+    {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+      stdio: ["ignore", "pipe", "inherit"],
+      env: { ...process.env, NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --expose-gc`.trim() },
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(`lint-one exited ${result.status} for ${target.name}`);
+  }
+  const lines = result.stdout.trim().split("\n");
+  return JSON.parse(lines[lines.length - 1]) as SubprocessResult;
+}
+
+function benchTarget(target: Target, opts: BenchOptions): TargetResult {
+  const colds: number[] = [];
+  const warms: number[] = [];
+  let diagnostics = 0;
+  let diagnosticsHash = "";
+  let peakRss = 0;
+  for (let i = 0; i < opts.subprocesses; i++) {
+    const r = runOnce(target, opts.repeats);
+    colds.push(r.cold_ms);
+    warms.push(...r.warm_ms);
+    diagnostics = r.diagnostics;
+    diagnosticsHash = r.diagnosticsHash;
+    peakRss = Math.max(peakRss, r.peakRssBytes);
+  }
+  return {
+    target: target.name,
+    cold_ms_median: median(colds),
+    cold_ms_min: Math.min(...colds),
+    cold_ms_max: Math.max(...colds),
+    warm_ms_median: median(warms),
+    warm_ms_min: Math.min(...warms),
+    warm_ms_max: Math.max(...warms),
+    diagnostics,
+    diagnosticsHash,
+    peakRssMB: Math.round((peakRss / (1024 * 1024)) * 10) / 10,
+  };
+}
+
+function printTable(results: readonly TargetResult[], baseline: readonly TargetResult[] | null): void {
+  const baselineByTarget = new Map(baseline?.map((r) => [r.target, r]) ?? []);
+  const rows: string[][] = [
+    ["target", "cold (med)", "warm (med)", "diagnostics", "RSS", "vs baseline"],
+  ];
+  for (const r of results) {
+    const b = baselineByTarget.get(r.target);
+    let delta = "—";
+    if (b !== undefined) {
+      const coldPct = ((r.cold_ms_median - b.cold_ms_median) / b.cold_ms_median) * 100;
+      const warmPct = ((r.warm_ms_median - b.warm_ms_median) / b.warm_ms_median) * 100;
+      const sign = (n: number): string => (n >= 0 ? "+" : "");
+      delta = `cold ${sign(coldPct)}${coldPct.toFixed(1)}% · warm ${sign(warmPct)}${warmPct.toFixed(1)}%`;
+    }
+    rows.push([
+      r.target,
+      `${fmt(r.cold_ms_median)} [${fmt(r.cold_ms_min)}–${fmt(r.cold_ms_max)}]`,
+      `${fmt(r.warm_ms_median)} [${fmt(r.warm_ms_min)}–${fmt(r.warm_ms_max)}]`,
+      String(r.diagnostics),
+      `${r.peakRssMB} MB`,
+      delta,
+    ]);
+  }
+  const widths = rows[0].map((_, i) => Math.max(...rows.map((row) => row[i].length)));
+  for (const row of rows) {
+    console.log(row.map((cell, i) => cell.padEnd(widths[i])).join("  "));
+  }
+}
+
+function loadBaseline(): readonly TargetResult[] | null {
+  if (!fs.existsSync(BASELINE_PATH)) return null;
+  const parsed = JSON.parse(fs.readFileSync(BASELINE_PATH, "utf8")) as {
+    results: TargetResult[];
+  };
+  return parsed.results;
+}
+
+function writeBaseline(results: readonly TargetResult[]): void {
+  fs.mkdirSync(path.dirname(BASELINE_PATH), { recursive: true });
+  const payload = {
+    capturedAt: new Date().toISOString(),
+    node: process.version,
+    results,
+  };
+  fs.writeFileSync(BASELINE_PATH, JSON.stringify(payload, null, 2) + "\n");
+  console.log(`\nwrote ${path.relative(REPO_ROOT, BASELINE_PATH)}`);
+}
+
+function main(): void {
+  const opts = parseOptions(process.argv.slice(2));
+  const targets = collectTargets(opts.only);
+  if (targets.length === 0) {
+    console.error("no targets matched; run `tsx bench/generate-fixture.ts` first");
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(path.join(REPO_ROOT, "dist/index.js"))) {
+    console.error("dist/index.js not found; run `pnpm build` first");
+    process.exit(1);
+  }
+
+  console.log(`bench: ${targets.length} target(s) × ${opts.subprocesses} subprocess(es) × ${opts.repeats} lint(s)`);
+
+  const results: TargetResult[] = [];
+  for (const target of targets) {
+    process.stdout.write(`  ${target.name}... `);
+    const r = benchTarget(target, opts);
+    results.push(r);
+    console.log(`cold ${fmt(r.cold_ms_median)}, warm ${fmt(r.warm_ms_median)}, ${r.diagnostics} diagnostics`);
+  }
+
+  console.log();
+  const baseline = loadBaseline();
+  printTable(results, baseline);
+
+  if (opts.writeBaseline) writeBaseline(results);
+}
+
+main();

--- a/bench/lint-one.ts
+++ b/bench/lint-one.ts
@@ -1,0 +1,125 @@
+import crypto from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { ESLint } from "eslint";
+
+interface Args {
+  readonly cwd: string;
+  readonly patterns: readonly string[];
+  readonly repeats: number;
+  readonly dumpPath: string | null;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  let cwd: string | null = null;
+  let patternsCsv: string | null = null;
+  let repeats = 4;
+  let dumpPath: string | null = null;
+
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    switch (flag) {
+      case "--cwd":
+        cwd = value;
+        i++;
+        break;
+      case "--patterns":
+        patternsCsv = value;
+        i++;
+        break;
+      case "--repeats":
+        repeats = Number.parseInt(value, 10);
+        i++;
+        break;
+      case "--dump":
+        dumpPath = value;
+        i++;
+        break;
+      default:
+        throw new Error(`unknown flag: ${flag}`);
+    }
+  }
+
+  if (cwd === null) throw new Error("--cwd is required");
+  const patterns = (patternsCsv ?? "src/**/*.ts").split(",");
+  return { cwd, patterns, repeats, dumpPath };
+}
+
+interface DiagnosticRow {
+  readonly file: string;
+  readonly ruleId: string;
+  readonly severity: number;
+  readonly message: string;
+}
+
+function flatten(results: readonly ESLint.LintResult[], cwd: string): DiagnosticRow[] {
+  const rows: DiagnosticRow[] = [];
+  for (const r of results) {
+    const relFile = r.filePath.startsWith(cwd) ? r.filePath.slice(cwd.length + 1) : r.filePath;
+    for (const m of r.messages) {
+      rows.push({
+        file: relFile,
+        ruleId: m.ruleId ?? "<no-rule>",
+        severity: m.severity,
+        message: m.message,
+      });
+    }
+  }
+  rows.sort((a, b) =>
+    a.file !== b.file
+      ? a.file.localeCompare(b.file)
+      : a.ruleId !== b.ruleId
+        ? a.ruleId.localeCompare(b.ruleId)
+        : a.message.localeCompare(b.message),
+  );
+  return rows;
+}
+
+function hash(rows: readonly DiagnosticRow[]): string {
+  const h = crypto.createHash("sha256");
+  for (const r of rows) h.update(`${r.file}\t${r.ruleId}\t${r.severity}\t${r.message}\n`);
+  return h.digest("hex").slice(0, 16);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const eslint = new ESLint({ cwd: args.cwd });
+
+  const timings: number[] = [];
+  let lastRows: DiagnosticRow[] = [];
+  let peakRss = 0;
+
+  for (let i = 0; i < args.repeats; i++) {
+    if (global.gc) global.gc();
+    const before = process.memoryUsage().rss;
+    const t0 = performance.now();
+    const results = await eslint.lintFiles([...args.patterns]);
+    const t1 = performance.now();
+    const after = process.memoryUsage().rss;
+    timings.push(t1 - t0);
+    peakRss = Math.max(peakRss, before, after);
+    lastRows = flatten(results, args.cwd);
+  }
+
+  if (args.dumpPath !== null) {
+    const fs = await import("node:fs");
+    fs.writeFileSync(args.dumpPath, JSON.stringify(lastRows, null, 2));
+  }
+
+  const output = {
+    cwd: args.cwd,
+    repeats: args.repeats,
+    cold_ms: timings[0],
+    warm_ms: timings.slice(1),
+    diagnostics: lastRows.length,
+    diagnosticsHash: hash(lastRows),
+    peakRssBytes: peakRss,
+  };
+
+  process.stdout.write(JSON.stringify(output) + "\n");
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`lint-one failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,10 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": [
     "src/**/*.test.ts",
-    "src/**/test-support/**/*.ts"
+    "src/**/test-support/**/*.ts",
+    "bench/lint-one.ts"
+  ],
+  "ignore": [
+    "bench/fixtures/**"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "lint": "eslint . && knip",
     "test": "vitest run --changed",
     "test:all": "vitest run",
+    "bench": "tsx bench/lint-bench.ts",
+    "bench:generate": "tsx bench/generate-fixture.ts",
     "mutation": "stryker run",
     "prepublishOnly": "pnpm build && pnpm test:all"
   },
@@ -68,6 +70,7 @@
     "@typescript-eslint/rule-tester": "^8.0.0",
     "eslint": "^9.0.0",
     "fast-check": "^4.7.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.4.0",
     "vitest": "^2.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       fast-check:
         specifier: ^4.7.0
         version: 4.7.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -233,9 +236,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -245,9 +260,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -257,9 +284,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -269,9 +308,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -281,9 +332,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -293,9 +356,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -305,9 +380,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -317,9 +404,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -329,11 +428,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -341,9 +464,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -353,15 +494,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1275,6 +1434,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1913,6 +2077,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
@@ -2305,70 +2474,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -3174,6 +3421,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -3852,6 +4128,13 @@ snapshots:
       typescript: 5.9.3
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel@0.0.6: {}
 


### PR DESCRIPTION
## Phase 0 of the architecture-rule performance plan

Plan: `/home/tapanc/.claude/plans/come-up-with-a-squishy-crown.md`

Adds a benchmark harness so each later phase has measurable before/after
evidence. Captures the pre-optimization baseline.

## What ships

- `bench/generate-fixture.ts` — deterministic synthetic TS projects
  (small=50, medium=500, large=1.5k, xlarge=5k files; seeded RNG)
- `bench/lint-one.ts` — subprocess: runs ESLint on one fixture N times,
  emits JSON (cold + warm timings, peak RSS, sorted diagnostic hash)
- `bench/lint-bench.ts` — orchestrator: spawns M subprocesses per
  target, reports median + min/max, diffs against `baseline.json`
- `bench/baselines/baseline.json` — committed pre-optimization numbers
- `bench/README.md`
- `pnpm bench` and `pnpm bench:generate` scripts; `tsx` devDep
- `knip.json` updated to recognize bench entries and ignore fixtures

## Baseline (median across 2 subprocesses × 3 lints per target)

| target | cold (med) | warm (med) | diagnostics | RSS |
|---|---|---|---|---|
| small (50 files) | 5.20s | 334ms | 136 | 528 MB |
| medium (500 files) | 9.20s | 3.92s | 1,383 | 725 MB |
| large (1,500 files) | 22.38s | 16.66s | 4,040 | 1,151 MB |
| self (this repo) | 19.68s | 11.19s | 0 | 1,469 MB |

## What the baseline reveals

The bench exposes the O(F·D) per-`(file × architecture rule)` hot path
the plan targets: warm time scales ~12× for 10× files (small→medium).
At medium, the inner listener loop does ~17M comparisons per warm lint
(25 rules × 500 files × 1,383 diagnostics). Phase 1 will index
diagnostics by filename and collapse this to ~D per visitor invocation.

`xlarge` (5,000 files) is opt-in only — pre-Phase-1 a single cold lint
takes ~10 min, so the default `pnpm bench` excludes it. Revisit after
Phase 1.

## Acceptance (from plan)

- [x] `pnpm bench` runs end-to-end against `small / medium / large / self`
- [x] `bench/baselines/baseline.json` committed with the run's medians
- [x] No changes to `src/`
- [x] `pnpm test:all` green (78 files, 926 tests)
- [x] `pnpm lint` green (eslint + knip)

## Test plan

- [ ] Verify `pnpm build && pnpm bench:generate && pnpm bench` reproduces
      the baseline shape on a fresh checkout (subprocess timings will vary)
- [ ] Confirm reviewer sees the bench infrastructure is appropriate for
      gating Phases 1–3

🤖 Generated with [Claude Code](https://claude.com/claude-code)