### PR TITLE
[impl-junior] phase 3: configurable cache TTL

### DIFF
--- a/src/rules/architecture/README.md
+++ b/src/rules/architecture/README.md
@@ -15,3 +15,18 @@ The implementation is organized by analysis surface:
 
 `index.ts` is the architecture analyzer facade. `plugin-rules.ts` adapts
 architecture diagnostics into individual ESLint rules and presets.
+
+## Performance
+
+The architecture analyzer runs once per project and is cached. The cache
+TTL defaults to 5 seconds so long-lived hosts (ESLint LSP, VS Code) see
+fixes promptly. CI lints finish in one pass, so a longer TTL is safe:
+
+```js
+const ARCHITECTURE_OPTIONS = {
+  // …
+  cacheTtlMs: Infinity, // CI: never rebuild within a single lint run
+};
+```
+
+Valid range: `0` (always rebuild) through `Infinity`.

--- a/src/rules/architecture/project/cache.test.ts
+++ b/src/rules/architecture/project/cache.test.ts
@@ -212,6 +212,16 @@ it("Property: schema enforces ratio option bounds inclusively", () => {
     .toBe(1);
 });
 
+it("defaults cacheTtlMs to 5000 and accepts Infinity for unlimited caching", () => {
+  expect(resolveArchitectureOptions({}).cacheTtlMs).toBe(5000);
+  expect(resolveArchitectureOptions({ cacheTtlMs: 0 }).cacheTtlMs).toBe(0);
+  expect(resolveArchitectureOptions({ cacheTtlMs: 60_000 }).cacheTtlMs).toBe(60_000);
+  expect(resolveArchitectureOptions({ cacheTtlMs: Infinity }).cacheTtlMs).toBe(Infinity);
+  expect(() => resolveArchitectureOptions({ cacheTtlMs: -1 })).toThrowError(
+    /cacheTtlMs/,
+  );
+});
+
 it("Property: schema rejects non-positive and non-integer count options", () => {
   const positiveIntOptions = [
     "minExportedSiblingModules",

--- a/src/rules/architecture/project/cache.ts
+++ b/src/rules/architecture/project/cache.ts
@@ -5,7 +5,8 @@ import { createProgram } from "./api/index.js";
 
 // Long-lived hosts (ESLint LSP, VS Code) reuse the cache across edits;
 // without a TTL, "fixed" diagnostics linger until the editor restarts.
-const REPORT_CACHE_TTL_MS = 5_000;
+// The TTL is configurable via the `cacheTtlMs` architecture option;
+// CI users can pass `Infinity` to disable invalidation entirely.
 
 interface CachedReport {
   readonly report: ArchitectureReport;
@@ -37,7 +38,7 @@ export function cachedProjectArchitecture(
   if (cached !== undefined && cached.expiresAt > now) return cached.report;
 
   const report = analyzeResolvedArchitecture(options, programProvider);
-  reportCache.set(cacheKey, { report, expiresAt: now + REPORT_CACHE_TTL_MS });
+  reportCache.set(cacheKey, { report, expiresAt: now + options.cacheTtlMs });
   return report;
 }
 

--- a/src/rules/architecture/project/config-schema.ts
+++ b/src/rules/architecture/project/config-schema.ts
@@ -228,6 +228,11 @@ const ArchitectureOptionsSchema = Schema.Struct({
   packageRuntime: PackageRuntime.pipe(
     Schema.optionalWith({ default: () => "universal" as const }),
   ),
+
+  cacheTtlMs: Schema.Number.pipe(
+    Schema.greaterThanOrEqualTo(0),
+    Schema.optionalWith({ default: () => 5_000 }),
+  ),
 });
 
 // Encoded = what users write in eslint.config.js (allowance arrays optional, etc.).


### PR DESCRIPTION
## Phase 3 of the architecture-rule performance plan

Plan: `/home/tapanc/.claude/plans/come-up-with-a-squishy-crown.md`
Stacked on: #61 (Phase 2) → #60 (Phase 1) → #59 (Phase 0)

The architecture report cache had a hardcoded 5-second TTL. The TTL
exists so long-lived hosts (ESLint LSP, VS Code) drop stale diagnostics
when the user fixes something. In CI, the TTL just causes pointless
rebuilds when a lint run exceeds 5 s — Phase 1 and 2 dramatically
reduced rule-loop cost, but the periodic full-project re-analysis still
fires inside long lints.

This PR exposes the TTL as the `cacheTtlMs` architecture option.
Default stays at 5 s (no behavior change). CI users opt into
`cacheTtlMs: Infinity` for max throughput.

## Diff

- `config-schema.ts` — new `cacheTtlMs: Schema.Number` field with
  `>= 0` bound and default `5_000`. `Infinity` validates cleanly
  (Effect's `greaterThanOrEqualTo(0)` admits it; rendered JSON schema
  is `{type: "number", minimum: 0}` which ajv accepts).
- `cache.ts` — replace the `REPORT_CACHE_TTL_MS` constant with
  `options.cacheTtlMs`; the resolved options object already carries
  the default, so call sites need no special casing.
- `cache.test.ts` — covers default, `0`, `60_000`, `Infinity`, and
  the negative-value rejection path.
- `README.md` — documents the CI tuning recipe.

## Acceptance (from plan)

- [x] `cacheTtlMs` field added to `architectureOptionsJsonSchema`
      (default `5000`, accepts `Infinity`)
- [x] Test covers both default-TTL and Infinity paths (and rejection
      of negatives)
- [x] `src/rules/architecture/README.md` documents CI tuning
- [x] No per-call regression (TTL check is unchanged; only the value
      it compares against now comes from options)
- [x] `pnpm test:all` green (78 files, 927 tests — +1 from prior phase)
- [x] `pnpm lint` green

## Note on mtime-based invalidation (rejected)

The plan considered mtime-based invalidation instead of a TTL. Rejected
because (a) mtime misses unsaved LSP edits — LSP would surface stale
findings until the user hit save, worse than the 5 s TTL, and (b)
content-hash invalidation costs more than the rebuild on small
projects. The configurable TTL gives CI users the "never expire"
behavior they need without compromising LSP responsiveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)