### PR TITLE
[impl-senior] phase 5b: workspace-scoped cache + dependency watermark

### DIFF
--- a/src/rules/architecture/project/cache/cache.test.ts
+++ b/src/rules/architecture/project/cache/cache.test.ts
@@ -59,6 +59,10 @@ it("normalizes options and clears the architecture cache without retaining stale
       projectRoot,
       minExportedSiblingModules: 1,
       maxExportedSiblingRatio: 0,
+      // Disable TTL — this test asserts cache holds until clear() is
+      // called, independent of wall-clock. Under parallel test load
+      // the 5s default can expire mid-test.
+      cacheTtlMs: Infinity,
     });
     const staleReport = cachedProjectArchitecture(options);
     expect(diagnosticsForRule(staleReport.diagnostics, "no-inventory-barrel")).toHaveLength(1);

--- a/src/rules/architecture/project/cache/dependency-watermark.ts
+++ b/src/rules/architecture/project/cache/dependency-watermark.ts
@@ -1,0 +1,81 @@
+/**
+ * @file Dependency watermark inputs for the architecture cache. Source
+ * files are watermarked in disk-cache.ts directly; this module covers
+ * the non-source inputs the analyzer reads (consumer's package.json,
+ * tsconfig content, and the analyzer's own version), so edits to any
+ * of them invalidate the persisted report.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { ResolvedArchitectureOptions } from "../diagnostics/index.js";
+
+const ANALYZER_VERSION_PSEUDO_PATH = "__analyzer_version__";
+const PACKAGE_JSON_PSEUDO_PATH_SUFFIX = "/__package_json__";
+const TSCONFIG_PSEUDO_PATH_SUFFIX = "/__tsconfig__";
+
+export interface DependencyWatermark {
+  readonly path: string;
+  readonly hash: string;
+}
+
+/**
+ * Watermark entries for analyzer inputs that aren't TypeScript source
+ * files. Edits to any of these change the report even when no `.ts`
+ * file changed, so they must participate in the cache watermark.
+ * @param options Resolved architecture options (used for projectRoot
+ * + tsconfig path).
+ * @param findTsconfig Optional override for tsconfig lookup; defaults
+ * to a tsconfig.json sibling of the project root.
+ * @returns Pseudo-watermark entries for package.json, tsconfig, and
+ * analyzer version.
+ */
+export function dependencyWatermarks(
+  options: ResolvedArchitectureOptions,
+  findTsconfig: (root: string) => string | undefined = (root) =>
+    path.join(root, "tsconfig.json"),
+): readonly DependencyWatermark[] {
+  const root = path.resolve(options.projectRoot);
+  const tsconfigPath = options.tsconfigPath ?? findTsconfig(root) ?? path.join(root, "tsconfig.json");
+  return [
+    { path: ANALYZER_VERSION_PSEUDO_PATH, hash: getAnalyzerVersion() },
+    {
+      path: `${root}${PACKAGE_JSON_PSEUDO_PATH_SUFFIX}`,
+      hash: hashFileOrAbsent(path.join(root, "package.json")),
+    },
+    {
+      path: `${root}${TSCONFIG_PSEUDO_PATH_SUFFIX}`,
+      hash: hashFileOrAbsent(tsconfigPath),
+    },
+  ];
+}
+
+function hashFileOrAbsent(filePath: string): string {
+  try {
+    const buf = fs.readFileSync(filePath);
+    return createHash("sha256").update(buf).digest("hex").slice(0, 32);
+  } catch (error) {
+    discardError(error);
+    return "absent";
+  }
+}
+
+let cachedAnalyzerVersion: string | null = null;
+function getAnalyzerVersion(): string {
+  if (cachedAnalyzerVersion !== null) return cachedAnalyzerVersion;
+  try {
+    const here = path.dirname(new URL(import.meta.url).pathname);
+    const pkgPath = path.resolve(here, "..", "..", "..", "..", "..", "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as { version?: string };
+    cachedAnalyzerVersion = pkg.version ?? "unknown";
+  } catch (error) {
+    discardError(error);
+    cachedAnalyzerVersion = "unknown";
+  }
+  return cachedAnalyzerVersion;
+}
+
+function discardError(_captured: unknown): null {
+  return null;
+}

--- a/src/rules/architecture/project/cache/disk-cache.ts
+++ b/src/rules/architecture/project/cache/disk-cache.ts
@@ -18,8 +18,12 @@ import type {
   ArchitectureReport,
   ResolvedArchitectureOptions,
 } from "../diagnostics/index.js";
+import { dependencyWatermarks } from "./dependency-watermark.js";
 
-const CACHE_VERSION = 1;
+// v2 bumped 2026-05-12: watermark now includes package.json, tsconfig
+// content, and analyzer version so dependency / config edits invalidate.
+// v1 caches read as null on next call.
+const CACHE_VERSION = 2;
 const CACHE_DIR_SEGMENTS = ["node_modules", ".cache", "agent-code-guard"];
 const CACHE_FILE = "report.json";
 
@@ -135,6 +139,14 @@ export function computeFileWatermark(
       // tsconfig). Treat as cache-busting by inventing a unique hash.
       watermarks.push({ path: filePath, hash: `missing-${Date.now()}` });
     }
+  }
+  // Pseudo-watermarks for analyzer behavior inputs that aren't source
+  // files: edits to any of these change the report even when no .ts
+  // file changed, so the watermark must capture them.
+  const tsconfigFinder = (root: string): string | undefined =>
+    ts.findConfigFile(root, ts.sys.fileExists, "tsconfig.json") ?? undefined;
+  for (const extra of dependencyWatermarks(options, tsconfigFinder)) {
+    watermarks.push(extra);
   }
   watermarks.sort((left, right) => left.path.localeCompare(right.path));
   return watermarks;

--- a/src/rules/architecture/project/cache/index.ts
+++ b/src/rules/architecture/project/cache/index.ts
@@ -1,10 +1,16 @@
 /**
- * @file Architecture report cache. Layered: a per-process in-memory
+ * @file Architecture report cache. Layered: a per-workspace in-memory
  * cache with the configurable `cacheTtlMs` TTL, backed by a persistent
  * on-disk report under `node_modules/.cache/agent-code-guard/` that
- * survives across linter processes. The in-memory layer absorbs the
- * per-`(file × rule)` lookup; the disk layer skips the analyzer
- * cold-build on the second and later `eslint` invocations.
+ * survives across linter processes.
+ *
+ * Workspace scoping: state is owned by a `WorkspaceCache` instance per
+ * `projectRoot`. The legacy `cachedProjectArchitecture` / `clearArchitectureCache`
+ * functions delegate to a process-level registry of those instances so
+ * ESLint plugin call sites keep working. Long-lived hosts (the LSP
+ * server) hold instances directly and call `clear()` on the relevant
+ * workspace only, so workspace A's edits do not blow workspace B's
+ * cache.
  */
 
 import type ts from "typescript";
@@ -20,84 +26,96 @@ import {
   writeDiskCache,
 } from "./disk-cache.js";
 
-// Long-lived hosts (ESLint LSP, VS Code) reuse the cache across edits;
-// without a TTL, "fixed" diagnostics linger until the editor restarts.
-// The TTL is configurable via the `cacheTtlMs` architecture option;
-// CI users can pass `Infinity` to disable invalidation entirely.
-
 interface CachedReport {
   readonly report: ArchitectureReport;
   readonly expiresAt: number;
 }
 
-const reportCache = new Map<string, CachedReport>();
-// Resolved options carry ~14 default arrays; serializing them on every rule
-// invocation is several KB of work per (file × rule). Memoize the key on the
-// options reference itself; the underlying memoization in resolveOptions
-// already guarantees the same input maps to the same resolved object.
-const keyCache = new WeakMap<ResolvedArchitectureOptions, string>();
-
-function cacheKeyFor(options: ResolvedArchitectureOptions): string {
-  const cached = keyCache.get(options);
-  if (cached !== undefined) return cached;
-  const key = JSON.stringify(options);
-  keyCache.set(options, key);
-  return key;
-}
-
 /**
- * Get the architecture report for a project, hitting the in-memory and
- * disk caches before triggering a fresh analyzer build. Subsequent
- * `eslint` invocations on an unchanged project return in ~20 ms via
- * the disk cache hit.
- * @param options Resolved architecture options (project root +
- * thresholds + allowance lists). The disk cache invalidates whenever
- * any field of this object hashes differently from the persisted run.
- * @param programProvider Lazy `ts.Program` provider used on cache
- * miss. Defaults to building a fresh program from the project
- * tsconfig; the architecture rule path passes a provider that returns
- * `parserServices.program` when typed-parser config is available.
- * @returns The architecture report (cached or freshly built).
+ * Per-workspace cache for the architecture report. Owns its own
+ * in-memory map plus the option-key memoization. The disk-cache layer
+ * is shared across workspaces but partitioned on `projectRoot`, so two
+ * instances over different roots never collide on the same file.
  */
-export function cachedProjectArchitecture(
-  options: ResolvedArchitectureOptions,
-  programProvider: () => ts.Program | null = () => createProgram(options),
-): ArchitectureReport {
-  const cacheKey = cacheKeyFor(options);
-  const now = Date.now();
-  const cached = reportCache.get(cacheKey);
-  if (cached !== undefined && cached.expiresAt > now) return cached.report;
+export class WorkspaceCache {
+  readonly #reportCache = new Map<string, CachedReport>();
+  readonly #keyCache = new WeakMap<ResolvedArchitectureOptions, string>();
 
-  const fromDisk = loadFromDiskCache(options);
-  if (fromDisk !== null) {
-    reportCache.set(cacheKey, { report: fromDisk, expiresAt: now + options.cacheTtlMs });
-    return fromDisk;
+  /**
+   * Read or build the architecture report for this workspace. Hits the
+   * in-memory entry first, then the disk cache, then the analyzer. The
+   * disk-cache path is skipped when `programFingerprint` is supplied
+   * (long-lived hosts with in-memory `ts.Program` overlays), so unsaved
+   * LSP buffers never collide with the persisted disk report.
+   * @param options Resolved architecture options for this workspace.
+   * @param programProvider Lazy `ts.Program` source on cache miss.
+   * @param programFingerprint Stable identifier of the program supplied
+   * by `programProvider` (e.g., LSP `LanguageService` version). When
+   * omitted, the cache treats the program as the canonical disk-backed
+   * one.
+   * @returns The architecture report.
+   */
+  get(
+    options: ResolvedArchitectureOptions,
+    programProvider: () => ts.Program | null = () => createProgram(options),
+    programFingerprint?: string,
+  ): ArchitectureReport {
+    const optionsKey = this.#optionsKey(options);
+    const cacheKey =
+      programFingerprint === undefined ? optionsKey : `${optionsKey}|${programFingerprint}`;
+    const now = Date.now();
+    const cached = this.#reportCache.get(cacheKey);
+    if (cached !== undefined && cached.expiresAt > now) return cached.report;
+
+    const fromDisk =
+      programFingerprint === undefined ? this.#loadFromDiskCache(options) : null;
+    if (fromDisk !== null) {
+      this.#reportCache.set(cacheKey, {
+        report: fromDisk,
+        expiresAt: now + options.cacheTtlMs,
+      });
+      return fromDisk;
+    }
+
+    const report = analyzeResolvedArchitecture(options, programProvider);
+    this.#reportCache.set(cacheKey, { report, expiresAt: now + options.cacheTtlMs });
+    if (programFingerprint === undefined) this.#persistToDiskCache(options, report);
+    return report;
   }
 
-  const report = analyzeResolvedArchitecture(options, programProvider);
-  reportCache.set(cacheKey, { report, expiresAt: now + options.cacheTtlMs });
-  persistToDiskCache(options, report);
-  return report;
-}
+  /**
+   * Drop every entry from this workspace's in-memory cache. Does not
+   * touch the on-disk report — that stays valid as long as its
+   * watermark matches.
+   */
+  clear(): void {
+    this.#reportCache.clear();
+  }
 
-function loadFromDiskCache(options: ResolvedArchitectureOptions): ArchitectureReport | null {
-  const persisted = readDiskCache(options.projectRoot);
-  if (persisted === null) return null;
-  if (persisted.optionsHash !== hashOptions(options)) return null;
-  const currentWatermark = computeFileWatermark(options);
-  if (!watermarksMatch(persisted.files, currentWatermark)) return null;
-  return hydrateReport(persisted);
-}
+  #optionsKey(options: ResolvedArchitectureOptions): string {
+    const cached = this.#keyCache.get(options);
+    if (cached !== undefined) return cached;
+    const key = JSON.stringify(options);
+    this.#keyCache.set(options, key);
+    return key;
+  }
 
-function persistToDiskCache(
-  options: ResolvedArchitectureOptions,
-  report: ArchitectureReport,
-): void {
-  try {
-    const files = computeFileWatermark(options);
-    writeDiskCache(options.projectRoot, report, files, hashOptions(options));
-  } catch (error) {
-    discardCacheWriteError(error);
+  #loadFromDiskCache(options: ResolvedArchitectureOptions): ArchitectureReport | null {
+    const persisted = readDiskCache(options.projectRoot);
+    if (persisted === null) return null;
+    if (persisted.optionsHash !== hashOptions(options)) return null;
+    const currentWatermark = computeFileWatermark(options);
+    if (!watermarksMatch(persisted.files, currentWatermark)) return null;
+    return hydrateReport(persisted);
+  }
+
+  #persistToDiskCache(options: ResolvedArchitectureOptions, report: ArchitectureReport): void {
+    try {
+      const files = computeFileWatermark(options);
+      writeDiskCache(options.projectRoot, report, files, hashOptions(options));
+    } catch (error) {
+      discardCacheWriteError(error);
+    }
   }
 }
 
@@ -107,11 +125,61 @@ function discardCacheWriteError(_captured: unknown): void {
   // covers the rest of this process.
 }
 
+const workspaceCaches = new Map<string, WorkspaceCache>();
+
 /**
- * Drop every entry from the in-memory cache. Tests call this between
- * fixtures so a previous test's report cannot mask a current test's
- * expectations; does not touch the on-disk cache.
+ * Get or create the cache instance for a given project root. Long-lived
+ * hosts (LSP server, etc.) call this to obtain a stable per-workspace
+ * cache they can `clear()` independently from other workspaces in the
+ * same process.
+ * @param projectRoot Absolute project root.
+ * @returns The cache instance for this workspace.
+ */
+export function getOrCreateWorkspaceCache(projectRoot: string): WorkspaceCache {
+  let cache = workspaceCaches.get(projectRoot);
+  if (cache === undefined) {
+    cache = new WorkspaceCache();
+    workspaceCaches.set(projectRoot, cache);
+  }
+  return cache;
+}
+
+/**
+ * Drop the in-memory cache for a specific workspace, leaving other
+ * workspaces' caches intact. Long-lived hosts call this on watcher
+ * events scoped to that workspace.
+ * @param projectRoot Absolute project root.
+ */
+export function clearWorkspaceCache(projectRoot: string): void {
+  workspaceCaches.get(projectRoot)?.clear();
+}
+
+/**
+ * Back-compat shim for the ESLint plugin call path: resolves the
+ * workspace cache for `options.projectRoot` and delegates. Existing
+ * callers keep the same signature; new code should prefer
+ * `getOrCreateWorkspaceCache(root).get(...)` so the workspace
+ * boundary is explicit.
+ * @param options Resolved architecture options (project root +
+ * thresholds + allowance lists).
+ * @param programProvider Lazy `ts.Program` provider used on cache
+ * miss.
+ * @returns The architecture report.
+ */
+export function cachedProjectArchitecture(
+  options: ResolvedArchitectureOptions,
+  programProvider: () => ts.Program | null = () => createProgram(options),
+): ArchitectureReport {
+  return getOrCreateWorkspaceCache(options.projectRoot).get(options, programProvider);
+}
+
+/**
+ * Drop every workspace's in-memory cache. Used by tests between
+ * fixtures and by hosts that want a hard reset; does not touch the
+ * on-disk cache. Long-lived hosts wanting to clear only one workspace
+ * should call `clearWorkspaceCache(projectRoot)` instead.
  */
 export function clearArchitectureCache(): void {
-  reportCache.clear();
+  for (const cache of workspaceCaches.values()) cache.clear();
+  workspaceCaches.clear();
 }

--- a/src/rules/architecture/project/cache/workspace-cache.test.ts
+++ b/src/rules/architecture/project/cache/workspace-cache.test.ts
@@ -1,0 +1,158 @@
+import { expect, it } from "vitest";
+import * as h from "../../test-support/helper-fixtures.js";
+
+const {
+  fs,
+  os,
+  path,
+  cachedProjectArchitecture,
+  clearArchitectureCache,
+  resolveArchitectureOptions,
+} = h;
+
+function writeFixtureProject(projectRoot: string): void {
+  fs.writeFileSync(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture",
+      version: "1.0.0",
+      type: "module",
+      exports: { ".": "./dist/index.js" },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(projectRoot, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        skipLibCheck: true,
+        declaration: true,
+        outDir: "./dist",
+        rootDir: "./src",
+      },
+      include: ["src/**/*"],
+    }),
+  );
+  fs.mkdirSync(path.join(projectRoot, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "src", "index.ts"),
+    [
+      'export { M0 } from "./m0.js";',
+      'export { M1 } from "./m1.js";',
+      'export { M2 } from "./m2.js";',
+      'export { M3 } from "./m3.js";',
+    ].join("\n"),
+  );
+  for (let i = 0; i < 4; i += 1) {
+    fs.writeFileSync(
+      path.join(projectRoot, "src", `m${i}.ts`),
+      `export const M${i} = ${i};\n`,
+    );
+  }
+}
+
+it("WorkspaceCache: clearing one workspace leaves other workspaces intact", () => {
+  const rootA = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-wsA-"));
+  const rootB = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-wsB-"));
+  try {
+    writeFixtureProject(rootA);
+    writeFixtureProject(rootB);
+    const optionsA = resolveArchitectureOptions({
+      projectRoot: rootA,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+    const optionsB = resolveArchitectureOptions({
+      projectRoot: rootB,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+
+    const reportA = cachedProjectArchitecture(optionsA);
+    const reportB = cachedProjectArchitecture(optionsB);
+
+    h.clearWorkspaceCache(rootA);
+
+    expect(cachedProjectArchitecture(optionsB)).toBe(reportB);
+    expect(cachedProjectArchitecture(optionsA).diagnostics).toEqual(reportA.diagnostics);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(rootA, { recursive: true, force: true });
+    fs.rmSync(rootB, { recursive: true, force: true });
+  }
+});
+
+it("watermark: editing package.json invalidates the disk cache", () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-pkg-"));
+  try {
+    writeFixtureProject(projectRoot);
+    const options = resolveArchitectureOptions({
+      projectRoot,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+    const before = cachedProjectArchitecture(options);
+    expect(before.diagnostics.length).toBeGreaterThan(0);
+
+    clearArchitectureCache();
+    fs.writeFileSync(
+      path.join(projectRoot, "package.json"),
+      JSON.stringify({ name: "fixture", version: "2.0.0", type: "module", exports: {} }),
+    );
+    const after = cachedProjectArchitecture(options);
+    expect(after).not.toBe(before);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+it("watermark: editing tsconfig.json invalidates the disk cache", () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-tscfg-"));
+  try {
+    writeFixtureProject(projectRoot);
+    const options = resolveArchitectureOptions({
+      projectRoot,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+    const before = cachedProjectArchitecture(options);
+    expect(before.diagnostics.length).toBeGreaterThan(0);
+
+    clearArchitectureCache();
+    const tsconfig = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, "tsconfig.json"), "utf8"),
+    ) as { compilerOptions: Record<string, unknown> };
+    tsconfig.compilerOptions.allowJs = true;
+    fs.writeFileSync(path.join(projectRoot, "tsconfig.json"), JSON.stringify(tsconfig));
+
+    const after = cachedProjectArchitecture(options);
+    expect(after).not.toBe(before);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+it("WorkspaceCache.get: programFingerprint keeps in-memory entries independent and skips disk persist", () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-fp-"));
+  try {
+    writeFixtureProject(projectRoot);
+    const options = resolveArchitectureOptions({
+      projectRoot,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+    const cache = h.getOrCreateWorkspaceCache(projectRoot);
+    const r1 = cache.get(options, undefined, "language-service-v1");
+    const r2 = cache.get(options, undefined, "language-service-v2");
+    expect(r1).not.toBe(r2);
+    expect(r1.diagnostics).toEqual(r2.diagnostics);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});

--- a/src/rules/architecture/test-support/helper-fixtures.ts
+++ b/src/rules/architecture/test-support/helper-fixtures.ts
@@ -41,7 +41,12 @@ export {
   packageNameFromFileName,
   packageNameFromSpecifier,
 } from "../type-surface/index.js";
-export { cachedProjectArchitecture, clearArchitectureCache } from "../project/cache/index.js";
+export {
+  cachedProjectArchitecture,
+  clearArchitectureCache,
+  clearWorkspaceCache,
+  getOrCreateWorkspaceCache,
+} from "../project/cache/index.js";
 export { uniqueDiagnostics } from "../project/diagnostics/index.js";
 export { resolveArchitectureOptions } from "../project/config.js";
 export { collectExportsValue, collectPackageExportEntries } from "../package-api/index.js";


### PR DESCRIPTION
## Phase 5b — autoplan-driven cache correctness fixes

Stacked on: #64 (Phase 5)
Driver: the LSP-plan autoplan review (Codex + an independent Claude subagent) flagged three correctness gaps in Phase 5's disk cache. They don't manifest in the ESLint plugin (always single-workspace, save-time-only) but any long-lived host will hit each one within hours. This PR fixes them before the LSP plan starts so the foundation ships correct.

## Three fixes

### 1. Workspace-scoped state (no more cross-workspace bleed)

Phase 5's `clearArchitectureCache()` was process-global. In a multi-workspace editor session, workspace A's edits would invalidate workspace B's cache.

- New `WorkspaceCache` class owns per-workspace `reportCache` + `keyCache`.
- New `getOrCreateWorkspaceCache(root)` + `clearWorkspaceCache(root)` API.
- `cachedProjectArchitecture` + `clearArchitectureCache` stay back-compat — internally delegate to the workspace registry.

### 2. Expanded watermark (catches package.json / tsconfig edits)

Phase 5's `computeFileWatermark` only hashed TypeScript source files. A `package.json` `exports` edit or a `tsconfig.compilerOptions.strict` toggle left a stale-but-valid cache.

- Watermark now includes sha256-128 of:
  - `<projectRoot>/package.json` content
  - `<projectRoot>/tsconfig.json` content
  - The analyzer's own version (read from agent-code-guard's `package.json` once per process)
- `CACHE_VERSION` bumped to 2 — v1 caches return null on next read.
- New `dependency-watermark.ts` module isolates the dependency-hash logic (also keeps `disk-cache.ts` under the max-lines budget).

### 3. Programmable cache key (LSP overlay support)

Phase 5's cache keys on `JSON.stringify(options)` only. The `programProvider` was invisible — LSP unsaved-buffer reports would collide on the same key as the disk-backed report.

- `WorkspaceCache.get(options, programProvider, programFingerprint?)` adds a fingerprint dimension.
- When `programFingerprint` is supplied (long-lived host with in-memory overlays), the disk-cache layer is skipped and the entry stays per-fingerprint.
- ESLint callers don't pass a fingerprint and hit the unchanged disk path.

## Impact

| metric | Phase 5 (baseline) | Phase 5b | delta |
|---|---|---|---|
| `large` cold | 22.4 s | 20.7 s | within noise |
| `large` warm | 16.7 s | 12.4 s | within noise (favorable run) |
| diagnosticsHash | `84a1d720…` | `84a1d720…` | parity ✓ |
| Tests | 927 | 931 (+4) | new coverage |

The four new tests cover the four bug classes:
- `WorkspaceCache: clearing one workspace leaves other workspaces intact`
- `watermark: editing package.json invalidates the disk cache`
- `watermark: editing tsconfig.json invalidates the disk cache`
- `WorkspaceCache.get: programFingerprint keeps in-memory entries independent and skips disk persist`

## Test stability fix

One pre-existing test (`normalizes options and clears the architecture cache without retaining stale reports`) was flaky under parallel load — it asserts cache identity across two calls but the 5-second TTL can expire mid-test. Added `cacheTtlMs: Infinity` to its options. The test's intent (cache holds until `clear()` is called) is preserved; the wall-clock dependency is removed.

## Why this PR before the LSP plan

The LSP plan's `Dependency: Phase 5b cache-fix PR` section documents exactly this prerequisite. Per the autoplan approval, the bugs ship as PR #65 against the Phase 5 branch first; LSP work then builds on a corrected foundation rather than carrying the bug-fix load through Phase A.

## Acceptance

- [x] Workspace-scoped clear test passes
- [x] package.json watermark test passes
- [x] tsconfig.json watermark test passes
- [x] programFingerprint independence test passes
- [x] `pnpm test:all` green (931 tests)
- [x] `pnpm lint` green (only pre-existing `source-files.ts` boundary-module warning carries over from Phase 5)
- [x] `pnpm bench` shows diagnosticsHash parity with Phase 5 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)