### PR TITLE
[impl-senior] LSP phase A: Effect-shaped WorkspaceEngine + watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/node": "^22.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@typescript-eslint/rule-tester": "^8.0.0",
+    "chokidar": "^5.0.0",
     "eslint": "^9.0.0",
     "fast-check": "^4.7.0",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@typescript-eslint/rule-tester':
         specifier: ^8.0.0
         version: 8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.7.0)
@@ -1350,6 +1353,10 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -1916,6 +1923,10 @@ packages:
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   refa@0.12.1:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
@@ -3333,6 +3344,10 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   cli-width@4.1.0: {}
 
   color-convert@2.0.1:
@@ -3969,6 +3984,8 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  readdirp@5.0.0: {}
 
   refa@0.12.1:
     dependencies:

--- a/src/server/test-support/fixtures.ts
+++ b/src/server/test-support/fixtures.ts
@@ -1,0 +1,86 @@
+/**
+ * @file Plain-Node fixture helpers for engine tests. Lives outside
+ * the Effect-shaped test file so the lint rule that flags raw
+ * `node:fs` in Effect files doesn't trip on temp-dir scaffolding.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tempDirs = new Set<string>();
+
+/**
+ * Create a temp dir with a minimal TS project the analyzer can lint.
+ * @returns The absolute project root.
+ */
+export function makeFixtureProject(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-engine-"));
+  tempDirs.add(root);
+  writeFixtureProject(root);
+  return root;
+}
+
+/**
+ * Remove every fixture dir created during this test run. Tests call
+ * this in `afterEach` so temp dirs don't leak.
+ */
+export function cleanupFixtures(): void {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+}
+
+/**
+ * Append a write to one of the fixture project's source files. Used
+ * to trigger watcher events.
+ * @param projectRoot Absolute project root from `makeFixtureProject`.
+ * @param relativePath Path under the project root (e.g. `src/m0.ts`).
+ * @param contents File contents to write.
+ */
+export function writeFile(projectRoot: string, relativePath: string, contents: string): void {
+  fs.writeFileSync(path.join(projectRoot, relativePath), contents);
+}
+
+function writeFixtureProject(projectRoot: string): void {
+  fs.writeFileSync(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture",
+      version: "1.0.0",
+      type: "module",
+      exports: { ".": "./dist/index.js" },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(projectRoot, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        skipLibCheck: true,
+        declaration: true,
+        outDir: "./dist",
+        rootDir: "./src",
+      },
+      include: ["src/**/*"],
+    }),
+  );
+  fs.mkdirSync(path.join(projectRoot, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "src", "index.ts"),
+    [
+      'export { M0 } from "./m0.js";',
+      'export { M1 } from "./m1.js";',
+      'export { M2 } from "./m2.js";',
+      'export { M3 } from "./m3.js";',
+    ].join("\n"),
+  );
+  for (let i = 0; i < 4; i += 1) {
+    fs.writeFileSync(
+      path.join(projectRoot, "src", `m${i}.ts`),
+      `export const M${i} = ${i};\n`,
+    );
+  }
+}

--- a/src/server/workspace-engine.test.ts
+++ b/src/server/workspace-engine.test.ts
@@ -1,0 +1,114 @@
+import path from "node:path";
+import { Duration, Effect, Either, Stream } from "effect";
+import { afterEach, expect, it } from "vitest";
+import { resolveArchitectureOptions } from "../rules/architecture/project/api/index.js";
+import { clearArchitectureCache } from "../rules/architecture/project/cache/index.js";
+import { cleanupFixtures, makeFixtureProject, writeFile } from "./test-support/fixtures.js";
+import {
+  WorkspaceEngineError,
+  makeWorkspaceEngine,
+  withWorkspaceEngine,
+} from "./workspace-engine.js";
+
+afterEach(() => {
+  cleanupFixtures();
+  clearArchitectureCache();
+});
+
+function makeOptions(root: string): ReturnType<typeof resolveArchitectureOptions> {
+  return resolveArchitectureOptions({
+    projectRoot: root,
+    minExportedSiblingModules: 1,
+    maxExportedSiblingRatio: 0,
+    cacheTtlMs: Infinity,
+  });
+}
+
+it("lintPaths returns diagnostics scoped to the requested files", () => {
+  const root = makeFixtureProject();
+  const indexPath = path.join(root, "src", "index.ts");
+
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const engine = yield* makeWorkspaceEngine(makeOptions(root));
+        const findings = yield* engine.lintPaths([indexPath]);
+        expect(findings.length).toBeGreaterThan(0);
+        expect(findings.every((d) => d.file === indexPath)).toBe(true);
+      }),
+    ),
+  );
+});
+
+it("invalidations stream emits when a watched file changes on disk", { timeout: 15_000 }, () => {
+  const root = makeFixtureProject();
+
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const engine = yield* makeWorkspaceEngine(makeOptions(root));
+        yield* engine.lintPaths([path.join(root, "src", "index.ts")]);
+
+        const fiber = yield* Effect.fork(
+          Stream.runHead(engine.invalidations).pipe(
+            Effect.timeoutOption(Duration.seconds(10)),
+          ),
+        );
+
+        // Give the forked fiber time to actually subscribe to the
+        // PubSub before we publish. With unbounded PubSub, messages
+        // emitted before a subscriber attaches are dropped.
+        yield* Effect.sleep(Duration.seconds(1));
+        yield* Effect.sync(() => writeFile(root, "src/m0.ts", "export const M0 = 99;\n"));
+
+        const result = yield* fiber.await;
+        if (result._tag !== "Success") {
+          expect.fail(`fiber failed: ${JSON.stringify(result)}`);
+        }
+        expect(result.value._tag).toBe("Some");
+      }),
+    ),
+  );
+});
+
+it("withWorkspaceEngine scopes the engine to one usage and releases on exit", () => {
+  const root = makeFixtureProject();
+
+  // Use the engine for one Effect chain. If the watcher leaked,
+  // vitest's --detect-open-handles surfaces it as a failure at exit.
+  return Effect.runPromise(
+    withWorkspaceEngine(makeOptions(root), (engine) =>
+      Effect.gen(function* () {
+        const findings = yield* engine.lintPaths([path.join(root, "src", "index.ts")]);
+        expect(findings.length).toBeGreaterThan(0);
+      }),
+    ),
+  );
+});
+
+it("lintPaths surfaces WorkspaceEngineError when the analyzer call throws", () =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const root = makeFixtureProject();
+        const engine = yield* makeWorkspaceEngine(makeOptions(root));
+        // Force a failure by passing a programProvider that throws.
+        const result = yield* engine
+          .lintPaths(
+            [path.join(root, "src", "index.ts")],
+            () => {
+              throw new Error("provider boom");
+            },
+            "fingerprint-test",
+          )
+          .pipe(Effect.either);
+        Either.match(result, {
+          onLeft: (err) => {
+            expect(err).toBeInstanceOf(WorkspaceEngineError);
+            expect(err.message).toContain("lintPaths failed");
+          },
+          onRight: () => expect.fail("expected Left/error"),
+        });
+      }),
+    ),
+  ));

--- a/src/server/workspace-engine.ts
+++ b/src/server/workspace-engine.ts
@@ -1,0 +1,183 @@
+/**
+ * @file Long-lived per-workspace engine that the LSP server consumes.
+ * Effect-shaped: the file watcher and PubSub are acquired through a
+ * `Scope` (callers wrap with `Effect.scoped` so the engine cannot leak
+ * resources), and `lintPaths` returns an `Effect` so callers can
+ * compose it with the rest of the LSP pipeline. Wraps the
+ * `WorkspaceCache` (Phase 5b) without changing it.
+ */
+
+import path from "node:path";
+import { type FSWatcher, watch as chokidarWatch } from "chokidar";
+import { Data, Effect, PubSub, Scope, Stream } from "effect";
+import type ts from "typescript";
+import {
+  clearWorkspaceCache,
+  getOrCreateWorkspaceCache,
+} from "../rules/architecture/project/cache/index.js";
+import type {
+  ArchitectureDiagnostic,
+  ResolvedArchitectureOptions,
+} from "../rules/architecture/project/api/index.js";
+
+/** Tag for engine-internal failure modes. */
+export class WorkspaceEngineError extends Data.TaggedError("WorkspaceEngineError")<{
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
+
+const IGNORED_SEGMENTS = ["node_modules", ".cache", "dist", "coverage"];
+const ANALYZER_INPUT_SUFFIXES = [".ts", ".tsx", ".mts", ".cts"];
+const ANALYZER_INPUT_BASENAMES = new Set(["package.json"]);
+const TSCONFIG_PREFIX = "tsconfig";
+
+function isIgnoredPath(filePath: string): boolean {
+  for (const segment of IGNORED_SEGMENTS) {
+    if (filePath.includes(`${path.sep}${segment}${path.sep}`)) return true;
+    if (filePath.endsWith(`${path.sep}${segment}`)) return true;
+  }
+  return false;
+}
+
+function isAnalyzerInput(filePath: string): boolean {
+  const base = path.basename(filePath);
+  if (ANALYZER_INPUT_BASENAMES.has(base)) return true;
+  if (base.startsWith(TSCONFIG_PREFIX) && base.endsWith(".json")) return true;
+  for (const suffix of ANALYZER_INPUT_SUFFIXES) {
+    if (base.endsWith(suffix)) return true;
+  }
+  return false;
+}
+
+/** Public surface of the engine. Created via `makeWorkspaceEngine`. */
+export interface WorkspaceEngine {
+  /**
+   * Look up diagnostics for the requested files. Hits the workspace
+   * cache (Phase 5b) and filters `diagnosticsByFile` to the requested
+   * set so the caller can `publishDiagnostics` per file.
+   * @param paths Absolute file paths.
+   * @param programProvider Optional `ts.Program` source (LSP
+   * `LanguageService` for overlay support).
+   * @param programFingerprint Required when `programProvider` is
+   * supplied; stable identifier of the program (e.g., monotonic LSP
+   * version) so overlay reports don't collide with the disk-backed one.
+   */
+  readonly lintPaths: (
+    paths: readonly string[],
+    programProvider?: () => ts.Program | null,
+    programFingerprint?: string,
+  ) => Effect.Effect<readonly ArchitectureDiagnostic[], WorkspaceEngineError>;
+
+  /**
+   * Stream of cache-invalidation signals. The cache is already cleared
+   * by the time a value is emitted; subscribers should re-publish
+   * diagnostics for their open documents.
+   */
+  readonly invalidations: Stream.Stream<void>;
+
+  /** Absolute project root this engine is scoped to. */
+  readonly projectRoot: string;
+}
+
+const acquireWatcher = (
+  projectRoot: string,
+): Effect.Effect<FSWatcher, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.async<FSWatcher>((resume) => {
+      // chokidar 5.x dropped glob support: watch the project root
+      // recursively and filter events in the listener instead.
+      const w = chokidarWatch(projectRoot, {
+        ignored: (filePath: string): boolean => isIgnoredPath(filePath),
+        ignoreInitial: true,
+        persistent: true,
+      });
+      w.on("ready", () => resume(Effect.succeed(w)));
+    }),
+    (w) =>
+      Effect.tryPromise({
+        try: () => w.close(),
+        catch: (cause) =>
+          new WorkspaceEngineError({ message: "watcher.close failed", cause }),
+      }).pipe(Effect.orDie),
+  );
+
+const wireWatcherToPubSub = (
+  watcher: FSWatcher,
+  pubsub: PubSub.PubSub<void>,
+  projectRoot: string,
+): void => {
+  const onChange = (filePath: string): void => {
+    if (!isAnalyzerInput(filePath)) return;
+    clearWorkspaceCache(projectRoot);
+    Effect.runFork(PubSub.publish(pubsub, undefined));
+  };
+  watcher.on("change", onChange);
+  watcher.on("add", onChange);
+  watcher.on("unlink", onChange);
+};
+
+const buildLintPaths =
+  (options: ResolvedArchitectureOptions) =>
+  (
+    paths: readonly string[],
+    programProvider?: () => ts.Program | null,
+    programFingerprint?: string,
+  ): Effect.Effect<readonly ArchitectureDiagnostic[], WorkspaceEngineError> =>
+    Effect.try({
+      try: () => {
+        const cache = getOrCreateWorkspaceCache(options.projectRoot);
+        const report = cache.get(options, programProvider, programFingerprint);
+        const found: ArchitectureDiagnostic[] = [];
+        for (const filePath of paths) {
+          const findings = report.diagnosticsByFile.get(path.resolve(filePath));
+          if (findings !== undefined) found.push(...findings);
+        }
+        return found;
+      },
+      catch: (cause) =>
+        new WorkspaceEngineError({
+          message: `lintPaths failed for ${options.projectRoot}`,
+          cause,
+        }),
+    });
+
+/**
+ * Acquire a workspace engine. The returned `Effect` requires a `Scope`
+ * (callers compose with `Effect.scoped` or a `Layer.scoped`); closing
+ * the scope releases the watcher and the PubSub, and clears this
+ * workspace's cache. No manual `dispose()` to forget.
+ * @param options Resolved architecture options for this workspace.
+ * @returns Effect producing the engine; depends on a Scope.
+ */
+export const makeWorkspaceEngine = (
+  options: ResolvedArchitectureOptions,
+): Effect.Effect<WorkspaceEngine, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const pubsub = yield* PubSub.unbounded<void>();
+    const watcher = yield* acquireWatcher(options.projectRoot);
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => clearWorkspaceCache(options.projectRoot)),
+    );
+    wireWatcherToPubSub(watcher, pubsub, options.projectRoot);
+    return {
+      projectRoot: options.projectRoot,
+      invalidations: Stream.fromPubSub(pubsub),
+      lintPaths: buildLintPaths(options),
+    };
+  }).pipe(Effect.withSpan("makeWorkspaceEngine"));
+
+/**
+ * Run an Effect with an engine acquired and released around it. The
+ * engine is built fresh, used by `use`, then disposed when the inner
+ * Effect resolves. Convenience over `Effect.scoped(makeWorkspaceEngine(…))`
+ * for one-shot callers (CLI tools, integration tests) that don't hold
+ * the engine across multiple operations.
+ * @param options Resolved architecture options for the workspace.
+ * @param use Function consuming the engine.
+ * @returns Effect with the engine's lifetime scoped to `use`.
+ */
+export const withWorkspaceEngine = <A, E, R>(
+  options: ResolvedArchitectureOptions,
+  use: (engine: WorkspaceEngine) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | WorkspaceEngineError, Exclude<R, Scope.Scope>> =>
+  Effect.scoped(Effect.flatMap(makeWorkspaceEngine(options), use));


### PR DESCRIPTION
## LSP Phase A — long-lived analyzer host

Stacked on: #65 (Phase 5b)

Builds the long-lived per-workspace engine that the LSP server (Phase B) will consume. Effect-shaped end-to-end per the user's direction during /autoplan: the watcher and PubSub are acquired through a `Scope` so the engine can't leak resources, and `lintPaths` returns an `Effect` so callers compose it with the rest of the LSP pipeline.

## API

```ts
makeWorkspaceEngine(options): Effect<WorkspaceEngine, never, Scope.Scope>

WorkspaceEngine.lintPaths(paths, programProvider?, programFingerprint?):
  Effect<readonly ArchitectureDiagnostic[], WorkspaceEngineError>

WorkspaceEngine.invalidations: Stream<void>

withWorkspaceEngine(options, use): scoped one-shot convenience
```

The engine wraps Phase 5b's `WorkspaceCache` without touching it. Phase 5b's `programFingerprint` dimension threads through to support future LSP overlay reports.

## Watcher

chokidar 5.x dropped glob support, so the watcher subscribes to the project root recursively and filters events in the handler:
- Watches all paths under `projectRoot`
- Ignores `node_modules/`, `.cache/`, `dist/`, `coverage/`
- Acts on events for `package.json`, `tsconfig*.json`, `.ts|.tsx|.mts|.cts`

On any matching event, `clearWorkspaceCache(projectRoot)` fires and a `void` signal publishes to the `invalidations` stream so LSP consumers re-publish diagnostics.

## Tests

4 tests, all Effect-shaped:
- **`lintPaths` scoping** — finding for a requested file is attached to that file; no leakage.
- **invalidations stream** — fork subscriber, write file, expect first stream emission within 10s.
- **`withWorkspaceEngine` lifecycle** — scope closure releases the watcher; `--detect-open-handles` would catch a leak.
- **`WorkspaceEngineError` error path** — a throwing `programProvider` surfaces as `Left<WorkspaceEngineError>`.

Fixture helpers live in `src/server/test-support/fixtures.ts` (plain Node `fs`) so the Effect test file doesn't import `node:fs` directly.

## Acceptance (from plan)

- [x] Document overlay path: Phase 5b's `programFingerprint` already does this; engine threads it through.
- [x] `chokidar` watcher with proper ignore filters.
- [x] `Scope`-managed resource lifecycle (no manual `dispose()` to forget).
- [x] `Effect`-shaped `lintPaths` for LSP pipeline composition.
- [x] `pnpm test:all` green (931 → 935 tests).
- [x] `pnpm lint` 0 errors (8 warnings: 4 are the new `server -> rules` cross-domain imports that warrant a facade in Phase B; 4 are pre-existing or single-test-scope).

## Why Effect-shaped

User direction during autoplan: "why is code not effectful". The engine is the place that introduces resources (file watcher, long-lived cache, listener registry) — `Effect.acquireRelease` + `Scope` make the "forgot to dispose" failure mode unrepresentable instead of an after-the-fact assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)