### PR TITLE
[impl-staff] LSP phase B: stdio LSP server (Effect-shaped handlers)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "./dist/index.d.ts",
   "bin": {
     "agent-code-guard-knip": "./dist/knip.js",
-    "agent-code-guard-init": "./dist/init.js"
+    "agent-code-guard-init": "./dist/init.js",
+    "agent-code-guard-lsp": "./dist/server/index.js"
   },
   "exports": {
     ".": {
@@ -56,7 +57,8 @@
     "effect": "^3.21.1",
     "eslint-plugin-jsdoc": "^62.9.0",
     "eslint-plugin-sonarjs": "^4.0.3",
-    "knip": "^6.12.1"
+    "knip": "^6.12.1",
+    "vscode-languageserver": "^9.0.1"
   },
   "peerDependencies": {
     "eslint": ">=9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       knip:
         specifier: ^6.12.1
         version: 6.12.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      vscode-languageserver:
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@stryker-mutator/core':
         specifier: ^9.6.1
@@ -2198,6 +2201,20 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
@@ -4250,6 +4267,19 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
 
   walk-up-path@4.0.0: {}
 

--- a/src/server/diagnostic-converter.ts
+++ b/src/server/diagnostic-converter.ts
@@ -1,0 +1,63 @@
+/**
+ * @file Convert analyzer `ArchitectureDiagnostic` values into LSP
+ * `Diagnostic` values for `publishDiagnostics`. Architecture findings
+ * are file-level (not line-range-bound) — they map to the start of the
+ * file with `agent-code-guard` as the source and the rule id as the
+ * code. Editors group findings by `code` automatically.
+ */
+
+import { pathToFileURL } from "node:url";
+import {
+  type Diagnostic,
+  DiagnosticSeverity,
+} from "vscode-languageserver";
+import type { ArchitectureDiagnostic } from "../rules/architecture/project/api/index.js";
+
+const FILE_HEAD_RANGE = {
+  start: { line: 0, character: 0 },
+  end: { line: 0, character: 1 },
+};
+
+/**
+ * Convert one analyzer diagnostic to an LSP diagnostic.
+ * @param finding Analyzer's architecture diagnostic.
+ * @returns LSP diagnostic, pinned to the start of the file.
+ */
+export function toLspDiagnostic(finding: ArchitectureDiagnostic): Diagnostic {
+  return {
+    range: FILE_HEAD_RANGE,
+    severity:
+      finding.severity === "error"
+        ? DiagnosticSeverity.Error
+        : DiagnosticSeverity.Warning,
+    code: finding.ruleId,
+    source: "agent-code-guard",
+    message: finding.message,
+  };
+}
+
+function fileToUri(filePath: string): string {
+  return pathToFileURL(filePath).toString();
+}
+
+/**
+ * Group analyzer diagnostics by file URI. The LSP server publishes
+ * one `publishDiagnostics` per URI, so we batch findings here.
+ * @param findings Findings from one or more files.
+ * @returns Map of URI to LSP diagnostics for that URI.
+ */
+export function groupByUri(
+  findings: readonly ArchitectureDiagnostic[],
+): ReadonlyMap<string, readonly Diagnostic[]> {
+  const groups = new Map<string, Diagnostic[]>();
+  for (const finding of findings) {
+    const uri = fileToUri(finding.file);
+    let bucket = groups.get(uri);
+    if (bucket === undefined) {
+      bucket = [];
+      groups.set(uri, bucket);
+    }
+    bucket.push(toLspDiagnostic(finding));
+  }
+  return groups;
+}

--- a/src/server/document-store.ts
+++ b/src/server/document-store.ts
@@ -1,0 +1,73 @@
+/**
+ * @file In-memory store of currently-open LSP documents. Tracks URI,
+ * version, text, and the workspace folder each document belongs to.
+ * Pure data plus Effect-wrapped accessors so the LSP handlers don't
+ * leak imperative state outside this module.
+ */
+
+import { Effect, Ref } from "effect";
+
+interface OpenDocument {
+  readonly uri: string;
+  readonly version: number;
+  readonly text: string;
+  readonly languageId: string;
+}
+
+export interface DocumentStore {
+  readonly open: (doc: OpenDocument) => Effect.Effect<void>;
+  readonly update: (
+    uri: string,
+    version: number,
+    text: string,
+  ) => Effect.Effect<void>;
+  readonly close: (uri: string) => Effect.Effect<void>;
+  readonly get: (uri: string) => Effect.Effect<OpenDocument | null>;
+  readonly listUris: () => Effect.Effect<readonly string[]>;
+}
+
+/**
+ * Build a fresh document store backed by an Effect `Ref`. Each
+ * accessor returns an Effect so the store is composable inside the
+ * LSP handler pipelines without leaking the underlying Map.
+ * @returns Effect producing a `DocumentStore`.
+ */
+export const makeDocumentStore = (): Effect.Effect<DocumentStore> =>
+  Effect.gen(function* () {
+    const ref = yield* Ref.make<ReadonlyMap<string, OpenDocument>>(new Map());
+
+    const open = (doc: OpenDocument): Effect.Effect<void> =>
+      Ref.update(ref, (map) => {
+        const next = new Map(map);
+        next.set(doc.uri, doc);
+        return next;
+      });
+
+    const update = (
+      uri: string,
+      version: number,
+      text: string,
+    ): Effect.Effect<void> =>
+      Ref.update(ref, (map) => {
+        const existing = map.get(uri);
+        if (existing === undefined) return map;
+        const next = new Map(map);
+        next.set(uri, { ...existing, version, text });
+        return next;
+      });
+
+    const close = (uri: string): Effect.Effect<void> =>
+      Ref.update(ref, (map) => {
+        const next = new Map(map);
+        next.delete(uri);
+        return next;
+      });
+
+    const get = (uri: string): Effect.Effect<OpenDocument | null> =>
+      Ref.get(ref).pipe(Effect.map((map) => map.get(uri) ?? null));
+
+    const listUris = (): Effect.Effect<readonly string[]> =>
+      Ref.get(ref).pipe(Effect.map((map) => [...map.keys()]));
+
+    return { open, update, close, get, listUris };
+  });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+/**
+ * @file `agent-code-guard-lsp` CLI bin. Builds a stdio LSP connection,
+ * boots the Effect-shaped server inside `Effect.scoped`, and runs
+ * forever (until the parent process closes stdin/stdout).
+ */
+
+import { Effect } from "effect";
+import {
+  ProposedFeatures,
+  createConnection,
+} from "vscode-languageserver/node.js";
+import { makeLspServer } from "./lsp-server.js";
+
+function reportFatal(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`[agent-code-guard-lsp] fatal: ${message}\n`);
+  process.exit(1);
+}
+
+function main(): void {
+  const connection = createConnection(ProposedFeatures.all);
+  // Effect.scoped owns the workspace engines' watchers + caches; when
+  // the parent process closes stdio Node exits and the scope's
+  // finalizers run for cleanup.
+  Effect.runPromise(Effect.scoped(makeLspServer(connection))).catch(reportFatal);
+}
+
+main();

--- a/src/server/lsp-server.test.ts
+++ b/src/server/lsp-server.test.ts
@@ -1,0 +1,117 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { Effect } from "effect";
+import { afterEach, expect, it } from "vitest";
+import {
+  cleanupFixtures,
+  makeFixtureProject,
+} from "./test-support/fixtures.js";
+import { clearArchitectureCache } from "../rules/architecture/project/cache/index.js";
+import { groupByUri, toLspDiagnostic } from "./diagnostic-converter.js";
+import { makeDocumentStore } from "./document-store.js";
+import { makeWorkspaceRegistry } from "./workspace-registry.js";
+
+afterEach(() => {
+  cleanupFixtures();
+  clearArchitectureCache();
+});
+
+it("diagnostic-converter: groups findings by URI and maps severity", () => {
+  const findings = [
+    {
+      ruleId: "no-folder-cycle" as const,
+      file: "/proj/src/a.ts",
+      severity: "error" as const,
+      message: "cycle",
+    },
+    {
+      ruleId: "no-large-folder" as const,
+      file: "/proj/src/a.ts",
+      severity: "warn" as const,
+      message: "large",
+    },
+    {
+      ruleId: "no-folder-cycle" as const,
+      file: "/proj/src/b.ts",
+      severity: "error" as const,
+      message: "cycle",
+    },
+  ];
+  const grouped = groupByUri(findings);
+  expect(grouped.size).toBe(2);
+  const aUri = pathToFileURL("/proj/src/a.ts").toString();
+  const bUri = pathToFileURL("/proj/src/b.ts").toString();
+  expect(grouped.get(aUri)?.length).toBe(2);
+  expect(grouped.get(bUri)?.length).toBe(1);
+  const aDiagnostics = grouped.get(aUri) ?? [];
+  expect(aDiagnostics[0].severity).toBe(1); // Error
+  expect(aDiagnostics[1].severity).toBe(2); // Warning
+  expect(aDiagnostics.every((d) => d.source === "agent-code-guard")).toBe(true);
+});
+
+it("diagnostic-converter: maps single finding to LSP diagnostic at file head", () => {
+  const lsp = toLspDiagnostic({
+    ruleId: "no-folder-cycle",
+    file: "/proj/x.ts",
+    severity: "error",
+    message: "cycle detected",
+  });
+  expect(lsp.range.start.line).toBe(0);
+  expect(lsp.range.start.character).toBe(0);
+  expect(lsp.code).toBe("no-folder-cycle");
+  expect(lsp.message).toBe("cycle detected");
+});
+
+it("document-store: open/update/close round-trip", () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* makeDocumentStore();
+      yield* store.open({ uri: "f:///a.ts", version: 1, text: "x", languageId: "typescript" });
+      const after = yield* store.get("f:///a.ts");
+      expect(after?.text).toBe("x");
+
+      yield* store.update("f:///a.ts", 2, "y");
+      const updated = yield* store.get("f:///a.ts");
+      expect(updated?.text).toBe("y");
+      expect(updated?.version).toBe(2);
+
+      const uris = yield* store.listUris();
+      expect(uris).toEqual(["f:///a.ts"]);
+
+      yield* store.close("f:///a.ts");
+      const gone = yield* store.get("f:///a.ts");
+      expect(gone).toBeNull();
+    }),
+  ));
+
+it("workspace-registry: register memoizes engines per projectRoot", () => {
+  const root = makeFixtureProject();
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const registry = yield* makeWorkspaceRegistry();
+        const first = yield* registry.register(root);
+        const second = yield* registry.register(root);
+        expect(second).toBe(first);
+        expect(first.projectRoot).toBe(root);
+
+        const lookup = yield* registry.findByProjectRoot(root);
+        expect(lookup).toBe(first);
+
+        const allRoots = yield* registry.listProjectRoots();
+        expect(allRoots).toEqual([root]);
+      }),
+    ),
+  );
+});
+
+it("workspace-registry: findByProjectRoot returns null for unknown roots", () =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const registry = yield* makeWorkspaceRegistry();
+        const lookup = yield* registry.findByProjectRoot(path.join("/non", "existent"));
+        expect(lookup).toBeNull();
+      }),
+    ),
+  ));

--- a/src/server/lsp-server.ts
+++ b/src/server/lsp-server.ts
@@ -1,0 +1,232 @@
+/**
+ * @file Stdio LSP server entry. Builds a vscode-languageserver
+ * `Connection`, registers handlers wired through Effect so the
+ * `WorkspaceEngine` (and its `Scope`-managed watcher + cache) live
+ * inside the Effect runtime. The server stays up until the parent
+ * process closes stdio; the ambient `Scope` releases every workspace
+ * engine on shutdown.
+ *
+ * V1 scope: save-time analysis. `didChange` updates the document
+ * store but doesn't re-lint; `didSave` clears the cache and republishes.
+ * The chokidar watcher catches out-of-band edits (git checkouts,
+ * external tools) and the invalidations stream triggers a republish.
+ * Live edit-in-flight diagnostics (TS LanguageService overlay) is
+ * deferred to a follow-up.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Effect, Scope, Stream } from "effect";
+import {
+  type Connection,
+  type InitializeParams,
+  type InitializeResult,
+  type PublishDiagnosticsParams,
+  TextDocumentSyncKind,
+} from "vscode-languageserver";
+import { clearWorkspaceCache } from "../rules/architecture/project/cache/index.js";
+import { groupByUri } from "./diagnostic-converter.js";
+import { type DocumentStore, makeDocumentStore } from "./document-store.js";
+import { type WorkspaceEngine } from "./workspace-engine.js";
+import { type WorkspaceRegistry, makeWorkspaceRegistry } from "./workspace-registry.js";
+
+interface ServerDeps {
+  readonly connection: Connection;
+  readonly docs: DocumentStore;
+  readonly registry: WorkspaceRegistry;
+}
+
+const findEngineForUri = (
+  registry: WorkspaceRegistry,
+  uri: string,
+): Effect.Effect<WorkspaceEngine | null> =>
+  Effect.gen(function* () {
+    const filePath = fileURLToPath(uri);
+    const roots = yield* registry.listProjectRoots();
+    // Pick the longest matching project root so nested workspaces map
+    // to the most specific one.
+    let best: { root: string; len: number } | null = null;
+    for (const root of roots) {
+      if (!filePath.startsWith(root + path.sep) && filePath !== root) continue;
+      if (best === null || root.length > best.len) best = { root, len: root.length };
+    }
+    if (best === null) return null;
+    return yield* registry.findByProjectRoot(best.root);
+  });
+
+const publishForUris = (
+  deps: ServerDeps,
+  engine: WorkspaceEngine,
+  uris: readonly string[],
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const filePaths = uris.map((uri) => fileURLToPath(uri));
+    const findings = yield* engine.lintPaths(filePaths).pipe(
+      Effect.catchAll(() => Effect.succeed([])),
+    );
+    const grouped = groupByUri(findings);
+    for (const uri of uris) {
+      const diagnostics = [...(grouped.get(uri) ?? [])];
+      yield* Effect.sync(() => {
+        const params: PublishDiagnosticsParams = { uri, diagnostics };
+        deps.connection.sendDiagnostics(params);
+      });
+    }
+  });
+
+const publishAllOpen = (
+  deps: ServerDeps,
+  engine: WorkspaceEngine,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const allUris = yield* deps.docs.listUris();
+    const inWorkspace: string[] = [];
+    for (const uri of allUris) {
+      const filePath = fileURLToPath(uri);
+      if (
+        filePath === engine.projectRoot ||
+        filePath.startsWith(engine.projectRoot + path.sep)
+      ) {
+        inWorkspace.push(uri);
+      }
+    }
+    if (inWorkspace.length > 0) yield* publishForUris(deps, engine, inWorkspace);
+  });
+
+const handleInitialize = (params: InitializeParams): InitializeResult => ({
+  capabilities: {
+    textDocumentSync: {
+      openClose: true,
+      change: TextDocumentSyncKind.Incremental,
+      save: { includeText: false },
+    },
+    workspace: {
+      workspaceFolders: {
+        supported: true,
+        changeNotifications: true,
+      },
+    },
+  },
+  serverInfo: { name: "agent-code-guard", version: "0.1.0" },
+});
+
+const registerInitialWorkspaces = (
+  deps: ServerDeps,
+  params: InitializeParams,
+): Effect.Effect<void, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const folders = params.workspaceFolders ?? [];
+    for (const folder of folders) {
+      const root = fileURLToPath(folder.uri);
+      const engine = yield* deps.registry.register(root);
+      // Re-publish for any docs in this workspace when its watcher fires.
+      yield* Effect.forkScoped(
+        Stream.runForEach(engine.invalidations, () => publishAllOpen(deps, engine)),
+      );
+    }
+  });
+
+const handleDidOpen = (
+  deps: ServerDeps,
+  td: { uri: string; languageId: string; version: number; text: string },
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* deps.docs.open(td);
+    const engine = yield* findEngineForUri(deps.registry, td.uri);
+    if (engine === null) return;
+    yield* publishForUris(deps, engine, [td.uri]);
+  });
+
+const handleDidSave = (
+  deps: ServerDeps,
+  uri: string,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const engine = yield* findEngineForUri(deps.registry, uri);
+    if (engine === null) return;
+    // Force-invalidate so the next lint sees the saved content, even
+    // if the watcher is slower than our handler.
+    yield* Effect.sync(() => clearWorkspaceCache(engine.projectRoot));
+    yield* publishAllOpen(deps, engine);
+  });
+
+const handleDidClose = (deps: ServerDeps, uri: string): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* deps.docs.close(uri);
+    yield* Effect.sync(() => {
+      deps.connection.sendDiagnostics({ uri, diagnostics: [] });
+    });
+  });
+
+const setupTextHandlers = (deps: ServerDeps): void => {
+  deps.connection.onInitialized(() => {
+    // Initial workspace registration is wired in the Effect program
+    // (see makeLspServer). Nothing to do here yet.
+  });
+
+  deps.connection.onDidOpenTextDocument((params) => {
+    Effect.runFork(handleDidOpen(deps, params.textDocument));
+  });
+
+  deps.connection.onDidChangeTextDocument((params) => {
+    const last = params.contentChanges.at(-1);
+    if (last === undefined || !("text" in last)) return;
+    // V1: update the document store but don't re-analyze on every
+    // keystroke. Live overlay diagnostics is a follow-up.
+    Effect.runFork(
+      deps.docs.update(params.textDocument.uri, params.textDocument.version, last.text),
+    );
+  });
+
+  deps.connection.onDidSaveTextDocument((params) => {
+    Effect.runFork(handleDidSave(deps, params.textDocument.uri));
+  });
+
+  deps.connection.onDidCloseTextDocument((params) => {
+    Effect.runFork(handleDidClose(deps, params.textDocument.uri));
+  });
+};
+
+/**
+ * Build the LSP server. Returns an Effect that resolves when the
+ * server has bound its handlers and started listening on the supplied
+ * connection. The Effect stays alive (Effect.never) so the ambient
+ * `Scope` keeps every workspace engine alive until shutdown.
+ * @param connection vscode-languageserver Connection (stdio in
+ * production, in-memory for tests).
+ * @returns Long-running Effect requiring a `Scope`.
+ */
+export const makeLspServer = (
+  connection: Connection,
+): Effect.Effect<void, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const docs = yield* makeDocumentStore();
+    const registry = yield* makeWorkspaceRegistry();
+    const deps: ServerDeps = { connection, docs, registry };
+
+    // Capture initialize params so we can register workspaces inside
+    // the Effect runtime (so engines join the ambient scope).
+    let initParams: InitializeParams | null = null;
+    yield* Effect.sync(() => {
+      connection.onInitialize((params) => {
+        initParams = params;
+        return handleInitialize(params);
+      });
+    });
+
+    setupTextHandlers(deps);
+
+    yield* Effect.sync(() => connection.listen());
+
+    // Poll for initialize to arrive, then register workspaces under
+    // the ambient Scope so engines release on server shutdown.
+    yield* Effect.gen(function* () {
+      while (initParams === null) {
+        yield* Effect.sleep("50 millis");
+      }
+      yield* registerInitialWorkspaces(deps, initParams);
+    });
+
+    yield* Effect.never;
+  }).pipe(Effect.withSpan("makeLspServer"));
+

--- a/src/server/workspace-registry.ts
+++ b/src/server/workspace-registry.ts
@@ -1,0 +1,101 @@
+/**
+ * @file Per-LSP-process registry of `WorkspaceEngine` instances. The
+ * LSP server registers one engine per workspace folder; this module
+ * memoizes engines on `projectRoot` so reopening a folder reuses the
+ * existing engine + cache.
+ *
+ * V1 design: engines live for the registry's `Scope` lifetime (i.e.,
+ * the LSP process). Per-workspace teardown via `unregister` is a
+ * follow-up — the LSP doesn't yet send `workspace/didChangeWorkspaceFolders`
+ * for removals in a way that warrants the scope-fork complexity.
+ */
+
+import { Effect, Ref, Scope } from "effect";
+import { resolveArchitectureOptions, type ArchitectureOptionsInput } from "../rules/architecture/project/api/index.js";
+import { type WorkspaceEngine, makeWorkspaceEngine } from "./workspace-engine.js";
+
+type EngineMap = ReadonlyMap<string, WorkspaceEngine>;
+
+function lookupEngine(map: EngineMap, projectRoot: string): WorkspaceEngine | undefined {
+  return map.get(projectRoot);
+}
+
+function insertEngine(
+  map: EngineMap,
+  projectRoot: string,
+  engine: WorkspaceEngine,
+): EngineMap {
+  const next = new Map(map);
+  next.set(projectRoot, engine);
+  return next;
+}
+
+function makeInserter(
+  projectRoot: string,
+  engine: WorkspaceEngine,
+): (map: EngineMap) => EngineMap {
+  return (map) => insertEngine(map, projectRoot, engine);
+}
+
+function makeLookup(projectRoot: string): (map: EngineMap) => WorkspaceEngine | null {
+  return (map) => lookupOrNull(map, projectRoot);
+}
+
+function lookupOrNull(map: EngineMap, projectRoot: string): WorkspaceEngine | null {
+  return map.get(projectRoot) ?? null;
+}
+
+function listKeys(map: EngineMap): readonly string[] {
+  return [...map.keys()];
+}
+
+export interface WorkspaceRegistry {
+  readonly register: (
+    projectRoot: string,
+    options?: ArchitectureOptionsInput,
+  ) => Effect.Effect<WorkspaceEngine, never, Scope.Scope>;
+
+  readonly findByProjectRoot: (
+    projectRoot: string,
+  ) => Effect.Effect<WorkspaceEngine | null>;
+
+  readonly listProjectRoots: () => Effect.Effect<readonly string[]>;
+}
+
+/**
+ * Build a registry whose engines share the ambient `Scope`. All
+ * registered engines release when that scope closes — which for the
+ * LSP server is process exit.
+ * @returns Effect producing the registry.
+ */
+export const makeWorkspaceRegistry = (): Effect.Effect<WorkspaceRegistry> =>
+  Effect.gen(function* () {
+    const ref = yield* Ref.make<ReadonlyMap<string, WorkspaceEngine>>(new Map());
+
+    const register = (
+      projectRoot: string,
+      options?: ArchitectureOptionsInput,
+    ): Effect.Effect<WorkspaceEngine, never, Scope.Scope> =>
+      Effect.gen(function* () {
+        const map = yield* Ref.get(ref);
+        const existing = lookupEngine(map, projectRoot);
+        if (existing !== undefined) return existing;
+        const resolved = resolveArchitectureOptions({
+          ...(options ?? {}),
+          projectRoot,
+        });
+        const engine = yield* makeWorkspaceEngine(resolved);
+        yield* Ref.update(ref, makeInserter(projectRoot, engine));
+        return engine;
+      });
+
+    const findByProjectRoot = (
+      projectRoot: string,
+    ): Effect.Effect<WorkspaceEngine | null> =>
+      Effect.map(Ref.get(ref), makeLookup(projectRoot));
+
+    const listProjectRoots = (): Effect.Effect<readonly string[]> =>
+      Effect.map(Ref.get(ref), listKeys);
+
+    return { register, findByProjectRoot, listProjectRoots };
+  });


### PR DESCRIPTION
## LSP Phase B — stdio server

Stacked on: #66 (Phase A)

Builds on Phase A's `WorkspaceEngine`. Stdio LSP server that publishes architecture diagnostics via `vscode-languageserver`, with handlers running inside the Effect runtime per the user's "full stack Effect" direction.

## Components

| File | Role |
|---|---|
| `src/server/document-store.ts` | `Ref`-backed map of open LSP documents. `Effect`-wrapped `open` / `update` / `close` / `get` / `listUris`. |
| `src/server/workspace-registry.ts` | Per-LSP-process registry of `WorkspaceEngine` instances keyed on `projectRoot`. V1: engines live for the registry's `Scope` (process lifetime). |
| `src/server/diagnostic-converter.ts` | `ArchitectureDiagnostic` → LSP `Diagnostic`. Findings are file-level (range pins to file head); `error`→`Error`, `warn`→`Warning`; `source: "agent-code-guard"`; `code: ruleId`. |
| `src/server/lsp-server.ts` | Assembles connection + document store + registry. Wires `onDidOpen` / `onDidChange` / `onDidSave` / `onDidClose` via `Effect.runFork`. Each handler body is an `Effect.gen` function. |
| `src/server/index.ts` | Bin entry — runs `makeLspServer` inside `Effect.scoped`. When the parent closes stdio Node exits, `Scope` finalizers release every workspace engine. |

## V1 scope: save-time analysis

- `didOpen` → store document + lint + publish.
- `didChange` → update document store. **No re-lint on every keystroke** (live overlay diagnostics deferred).
- `didSave` → force `clearWorkspaceCache(projectRoot)` + publish for every open document in the workspace.
- `didClose` → drop document + publish empty diagnostics (clears editor squigglies).
- Out-of-band edits caught by Phase A's `chokidar` watcher → `Stream.runForEach(engine.invalidations, …)` triggers republish.

Live edit-in-flight overlay diagnostics via TS `LanguageService` host is a follow-up. The `programFingerprint` plumbing is already in Phase A/Phase 5b ready for it.

## Effect-shaped handlers

Each handler is an `Effect.gen` function. The LSP framework's callback API is bridged via `Effect.runFork` at the boundary:

```ts
deps.connection.onDidOpenTextDocument((params) => {
  Effect.runFork(handleDidOpen(deps, params.textDocument));
});
```

`handleDidOpen` / `handleDidSave` / `handleDidClose` are extracted module-level Effects that compose with `document-store` and the workspace registry. No `void Effect.runPromise(...)` patterns — `Effect.runFork` returns a `Fiber`, not a `Promise`, so there's nothing to ignore.

## Tests

5 unit tests covering the building blocks:
- `diagnostic-converter`: groups findings by URI; severity mapping.
- `diagnostic-converter`: single-finding maps to LSP diagnostic at file head.
- `document-store`: open / update / close round-trip via Effect.
- `workspace-registry`: `register` memoizes engines per `projectRoot`.
- `workspace-registry`: `findByProjectRoot` returns null for unknown roots.

**Integration test deferred** — wiring an in-process LSP harness with cross-paired streams + `createProtocolConnection` is more plumbing than its testing value. The Phase C sideload test runs Claude Code against the real LSP plugin which exercises the protocol end-to-end against a real server.

940 tests pass total.

## Footprint

- New runtime dep: `vscode-languageserver`
- New bin: `agent-code-guard-lsp` → `./dist/server/index.js`
- 0 lint errors. 19 warnings (4 are the expected `server -> rules` cross-domain imports addressed by a facade in Phase C; the rest are pre-existing or single-test-scope from prior phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)