### PR TITLE
[impl-junior] LSP phase C: Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "agent-code-guard",
+  "version": "0.1.0",
+  "description": "Long-lived architecture analyzer for TypeScript editors. Publishes diagnostics for cycles, large folders, public-API leaks, and other architecture findings via LSP.",
+  "author": {
+    "name": "Tapan Chugh",
+    "url": "https://github.com/chughtapan"
+  },
+  "homepage": "https://github.com/chughtapan/agent-code-guard#readme",
+  "repository": "https://github.com/chughtapan/agent-code-guard",
+  "license": "MIT",
+  "keywords": ["typescript", "architecture", "lsp", "linter"],
+  "lspServers": {
+    "agent-code-guard": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/server/index.js"],
+      "extensionToLanguage": {
+        ".ts": "typescript",
+        ".tsx": "typescriptreact",
+        ".mts": "typescript",
+        ".cts": "typescript"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -300,6 +300,21 @@ cd ~/.claude/skills/agent-code-guard && pnpm install
 
 **Alternatively**, invoke the `/safer:setup` skill to automate both steps on your behalf (wires floor → `eslint.config.js`, installs ceiling skill).
 
+## Claude Code LSP plugin
+
+This repo also ships as a Claude Code plugin that runs the same architecture analyzer as a long-lived **LSP server**. Editor users get sub-100 ms diagnostics on the file they're working in (cycles, large folders, public-API leaks, etc.) without ESLint's per-process startup cost on every save.
+
+```bash
+# Sideload from a local clone
+git clone https://github.com/chughtapan/agent-code-guard
+cd agent-code-guard && pnpm install && pnpm build
+claude --plugin .
+```
+
+Once installed, Claude Code starts `agent-code-guard-lsp` on the first TypeScript file you open. Diagnostics publish on `didOpen` and re-publish on `didSave`. The analyzer's disk cache (`node_modules/.cache/agent-code-guard/report.json`) shares state with the ESLint plugin so you don't pay the cold-build twice.
+
+The LSP plugin is **additive** — it doesn't replace the ESLint plugin. Use both if you want lint-time enforcement plus editor-time feedback.
+
 ## Development
 
 ```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "files": [
     "dist",
     "docs",
+    ".claude-plugin",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## LSP Phase C — Claude Code plugin manifest

Stacked on: #67 (Phase B)

Declares the LSP server as a Claude Code plugin so sideload (and future marketplace install) Just Works.

## Files

- `.claude-plugin/plugin.json` — standard plugin manifest. Single `lspServers` entry pointing at `\${CLAUDE_PLUGIN_ROOT}/dist/server/index.js` (the bin from Phase B). `extensionToLanguage` covers `.ts` / `.tsx` / `.mts` / `.cts` so the server fires for every TypeScript dialect.
- `README.md` — new \"Claude Code LSP plugin\" section. Distinct from the existing skill-based companion plugin: this one is an LSP server, not skills. Calls out that it's additive to the ESLint plugin and shares the disk cache.
- `package.json` `files` — adds `.claude-plugin/` to the npm tarball so a future npm-based install carries the manifest.

## Sideload

```bash
git clone https://github.com/chughtapan/agent-code-guard
cd agent-code-guard && pnpm install && pnpm build
claude --plugin .
```

Claude Code reads `.claude-plugin/plugin.json` on install, registers the LSP server entry, and spawns it on the first matching file open.

## Verification (manual, deferred to Phase D)

The full sideload-test runbook lives in Phase D's `docs/lsp.md`. The minimum smoke test for this PR:

1. `pnpm build` produces `dist/server/index.js`
2. The plugin manifest validates against the Claude Code plugin schema (`$schema` linked in the manifest)
3. `claude --plugin .` doesn't error on install

## What this doesn't ship

- Marketplace publish (deferred — manual Anthropic-side review step)
- LSP server tests via the real Claude Code runtime (deferred to Phase D's end-to-end parity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)