### PR TITLE
fix(server): dogfood findings — LSP install path + handler race + marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "agent-code-guard",
+  "owner": {
+    "name": "Tapan Chugh",
+    "url": "https://github.com/chughtapan"
+  },
+  "plugins": [
+    {
+      "name": "agent-code-guard",
+      "source": "./",
+      "version": "0.1.0",
+      "description": "Long-lived architecture analyzer for TypeScript editors (LSP).",
+      "author": { "name": "Tapan Chugh" },
+      "homepage": "https://github.com/chughtapan/agent-code-guard",
+      "repository": "https://github.com/chughtapan/agent-code-guard",
+      "license": "MIT",
+      "keywords": ["typescript", "architecture", "lsp", "linter"]
+    }
+  ]
+}

--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,8 @@
     "src/**/*.test.ts",
     "src/**/test-support/**/*.ts",
     "bench/lint-one.ts",
-    "bench/listener-microbench.ts"
+    "bench/listener-microbench.ts",
+    "scripts/dogfood-lsp.ts"
   ],
   "ignore": [
     "bench/fixtures/**"

--- a/scripts/dogfood-lsp.ts
+++ b/scripts/dogfood-lsp.ts
@@ -1,0 +1,180 @@
+/**
+ * @file Spawns dist/server/index.js as a subprocess, talks real LSP
+ * protocol to it via stdin/stdout, and reports the diagnostics the
+ * server publishes for a few files in THIS repo. End-to-end smoke
+ * test of the LSP plugin against the agent-code-guard codebase itself.
+ *
+ * Run: pnpm build && pnpm tsx scripts/dogfood-lsp.ts
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REPO = path.resolve(import.meta.dirname, "..");
+const LSP_BIN = path.join(REPO, "dist/server/index.js");
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: unknown) => void;
+}
+
+interface JsonRpcMessage {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+class LspClient {
+  readonly #proc;
+  readonly #pending = new Map<number, PendingRequest>();
+  #nextId = 1;
+  #buffer = Buffer.alloc(0);
+  readonly diagnostics: Array<{ uri: string; diagnostics: ReadonlyArray<unknown> }> = [];
+
+  constructor() {
+    this.#proc = spawn("node", [LSP_BIN], {
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    this.#proc.stdout.on("data", (chunk: Buffer) => this.#handleChunk(chunk));
+    this.#proc.on("exit", (code) => {
+      if (code !== null && code !== 0) console.error(`LSP exited with ${code}`);
+    });
+  }
+
+  send(method: string, params: unknown, isRequest: boolean): Promise<unknown> {
+    if (isRequest) {
+      const id = this.#nextId++;
+      const message: JsonRpcMessage = { jsonrpc: "2.0", id, method, params };
+      this.#write(message);
+      return new Promise((resolve, reject) => {
+        this.#pending.set(id, { resolve, reject });
+      });
+    }
+    this.#write({ jsonrpc: "2.0", method, params });
+    return Promise.resolve(undefined);
+  }
+
+  shutdown(): void {
+    this.#proc.kill();
+  }
+
+  #write(message: JsonRpcMessage): void {
+    const body = JSON.stringify(message);
+    const header = `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n`;
+    this.#proc.stdin.write(header + body);
+  }
+
+  #handleChunk(chunk: Buffer): void {
+    this.#buffer = Buffer.concat([this.#buffer, chunk]);
+    while (true) {
+      const headerEnd = this.#buffer.indexOf("\r\n\r\n");
+      if (headerEnd < 0) return;
+      const header = this.#buffer.subarray(0, headerEnd).toString("utf8");
+      const match = /Content-Length: (\d+)/.exec(header);
+      if (match === null) {
+        this.#buffer = this.#buffer.subarray(headerEnd + 4);
+        continue;
+      }
+      const length = parseInt(match[1], 10);
+      const bodyStart = headerEnd + 4;
+      if (this.#buffer.length < bodyStart + length) return;
+      const body = this.#buffer.subarray(bodyStart, bodyStart + length).toString("utf8");
+      this.#buffer = this.#buffer.subarray(bodyStart + length);
+      this.#dispatch(JSON.parse(body) as JsonRpcMessage);
+    }
+  }
+
+  #dispatch(msg: JsonRpcMessage): void {
+    if (msg.method === "textDocument/publishDiagnostics" && msg.params !== undefined) {
+      this.diagnostics.push(msg.params as { uri: string; diagnostics: ReadonlyArray<unknown> });
+      return;
+    }
+    if (typeof msg.id === "number") {
+      const pending = this.#pending.get(msg.id);
+      if (pending !== undefined) {
+        this.#pending.delete(msg.id);
+        if (msg.error !== undefined) pending.reject(msg.error);
+        else pending.resolve(msg.result);
+      }
+    }
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  console.log("==> spawning LSP server:", LSP_BIN);
+  const client = new LspClient();
+
+  try {
+    console.log("==> sending initialize for", REPO);
+    const initResult = await client.send(
+      "initialize",
+      {
+        processId: process.pid,
+        capabilities: {},
+        rootUri: pathToFileURL(REPO).toString(),
+        workspaceFolders: [
+          { uri: pathToFileURL(REPO).toString(), name: "agent-code-guard" },
+        ],
+      },
+      true,
+    );
+    console.log("    initialize result:", JSON.stringify(initResult, null, 2).slice(0, 200), "...");
+    await client.send("initialized", {}, false);
+
+    const targets = [
+      "src/index.ts",
+      "src/server/lsp-server.ts",
+      "src/server/workspace-engine.ts",
+      "src/rules/architecture/index.ts",
+    ];
+
+    for (const rel of targets) {
+      const filePath = path.join(REPO, rel);
+      const uri = pathToFileURL(filePath).toString();
+      console.log(`==> didOpen ${rel}`);
+      await client.send(
+        "textDocument/didOpen",
+        {
+          textDocument: {
+            uri,
+            languageId: "typescript",
+            version: 1,
+            text: "",
+          },
+        },
+        false,
+      );
+    }
+
+    // Wait for the analyzer's cold build + first batch of publishDiagnostics.
+    console.log("==> waiting up to 15s for diagnostics ...");
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline && client.diagnostics.length < targets.length) {
+      await sleep(200);
+    }
+
+    console.log(`\n==> received ${client.diagnostics.length} publishDiagnostics events:\n`);
+    for (const pub of client.diagnostics) {
+      const rel = path.relative(REPO, pub.uri.replace("file://", ""));
+      console.log(`  ${rel}: ${pub.diagnostics.length} diagnostics`);
+      for (const d of pub.diagnostics) {
+        const { code, message, severity } = d as { code: string; message: string; severity: number };
+        const sev = severity === 1 ? "ERROR" : "WARN";
+        console.log(`    [${sev}] ${code}`);
+        console.log(`           ${message.slice(0, 140)}${message.length > 140 ? "…" : ""}`);
+      }
+    }
+  } finally {
+    client.shutdown();
+  }
+}
+
+await main();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,6 +9,8 @@
 import { Effect } from "effect";
 import {
   ProposedFeatures,
+  StreamMessageReader,
+  StreamMessageWriter,
   createConnection,
 } from "vscode-languageserver/node.js";
 import { makeLspServer } from "./lsp-server.js";
@@ -20,7 +22,14 @@ function reportFatal(error: unknown): void {
 }
 
 function main(): void {
-  const connection = createConnection(ProposedFeatures.all);
+  // Use explicit stream readers/writers on process stdio so the bin
+  // works under Claude Code's plugin runtime (which spawns us with
+  // no transport flags) and under direct invocation alike.
+  const connection = createConnection(
+    ProposedFeatures.all,
+    new StreamMessageReader(process.stdin),
+    new StreamMessageWriter(process.stdout),
+  );
   // Effect.scoped owns the workspace engines' watchers + caches; when
   // the parent process closes stdio Node exits and the scope's
   // finalizers run for cleanup.

--- a/src/server/lsp-server.ts
+++ b/src/server/lsp-server.ts
@@ -16,7 +16,7 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { Effect, Scope, Stream } from "effect";
+import { Deferred, Effect, Scope, Stream } from "effect";
 import {
   type Connection,
   type InitializeParams,
@@ -34,6 +34,14 @@ interface ServerDeps {
   readonly connection: Connection;
   readonly docs: DocumentStore;
   readonly registry: WorkspaceRegistry;
+
+  /**
+   * Resolves after the workspaces named in `initialize.workspaceFolders`
+   * have been registered. Every text-document handler awaits this so
+   * a `didOpen` arriving before registration completes still publishes
+   * diagnostics once the engine exists.
+   */
+  readonly ready: Deferred.Deferred<void>;
 }
 
 const findEngineForUri = (
@@ -132,6 +140,7 @@ const handleDidOpen = (
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     yield* deps.docs.open(td);
+    yield* Deferred.await(deps.ready);
     const engine = yield* findEngineForUri(deps.registry, td.uri);
     if (engine === null) return;
     yield* publishForUris(deps, engine, [td.uri]);
@@ -142,6 +151,7 @@ const handleDidSave = (
   uri: string,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
+    yield* Deferred.await(deps.ready);
     const engine = yield* findEngineForUri(deps.registry, uri);
     if (engine === null) return;
     // Force-invalidate so the next lint sees the saved content, even
@@ -202,7 +212,8 @@ export const makeLspServer = (
   Effect.gen(function* () {
     const docs = yield* makeDocumentStore();
     const registry = yield* makeWorkspaceRegistry();
-    const deps: ServerDeps = { connection, docs, registry };
+    const ready = yield* Deferred.make<void>();
+    const deps: ServerDeps = { connection, docs, registry, ready };
 
     // Capture initialize params so we can register workspaces inside
     // the Effect runtime (so engines join the ambient scope).
@@ -220,12 +231,17 @@ export const makeLspServer = (
 
     // Poll for initialize to arrive, then register workspaces under
     // the ambient Scope so engines release on server shutdown.
-    yield* Effect.gen(function* () {
-      while (initParams === null) {
-        yield* Effect.sleep("50 millis");
-      }
-      yield* registerInitialWorkspaces(deps, initParams);
-    });
+    // Resolve `ready` once registration completes so handlers waiting
+    // on it can proceed.
+    yield* Effect.forkScoped(
+      Effect.gen(function* () {
+        while (initParams === null) {
+          yield* Effect.sleep("50 millis");
+        }
+        yield* registerInitialWorkspaces(deps, initParams);
+        yield* Deferred.succeed(ready, undefined);
+      }),
+    );
 
     yield* Effect.never;
   }).pipe(Effect.withSpan("makeLspServer"));


### PR DESCRIPTION
## Dogfood findings

Stacked on: #69 (LSP Phase D)

Real end-to-end dogfood (run the LSP against this very repo; install the plugin via `claude plugin install`) surfaced three concrete bugs that the unit tests didn't catch:

### 1. `createConnection(ProposedFeatures.all)` failed on spawn

`vscode-languageserver` couldn't auto-detect a transport. Server died with \"Connection input stream is not set\" on the first incoming message.

**Fix:** pass explicit `StreamMessageReader(process.stdin)` + `StreamMessageWriter(process.stdout)`. Works under Claude Code's plugin runtime AND under direct subprocess spawn (which is how the dogfood script invokes it).

### 2. `didOpen` → handler race vs `registerInitialWorkspaces`

The polling loop registered workspaces asynchronously after `initialize` returned. Clients reasonably send `didOpen` immediately after `initialized`, so handlers fired before any workspace existed in the registry. `findEngineForUri` returned null → handler bailed → 0 diagnostics published.

**Fix:** replaced the polling loop with an Effect `Deferred<void>` that resolves when registration completes. Every text-document handler awaits it. Concrete Effect-shaped synchronization, no fs walks, no manual polling.

**Side effect:** dropped a `fs.existsSync` walk I'd added as a fallback. With the Deferred synchronization right, the fallback isn't needed — user flagged it (\"why using raw node:fs and stuff instead of using effect\") and it turned out to be solving a problem the Deferred already solves.

### 3. `claude plugin install` needs a marketplace manifest

`claude plugin marketplace add /path/to/repo` requires `.claude-plugin/marketplace.json`, not just `plugin.json`. Without it the install fails with \"Marketplace file not found\".

**Fix:** added `.claude-plugin/marketplace.json` declaring this repo as a one-plugin marketplace. End-to-end install now works:
```bash
claude plugin marketplace add /path/to/agent-code-guard
claude plugin install agent-code-guard@agent-code-guard
```

## Dogfood evidence

`scripts/dogfood-lsp.ts` spawns the built bin, talks JSON-RPC to it via stdin/stdout, sends `initialize` + `didOpen` for four files in this repo, and prints what `publishDiagnostics` notifications come back:

```
==> received 4 publishDiagnostics events:

  src/index.ts: 2 diagnostics
    [WARN]  no-public-vendor-type-leak     \"default\" references \"node\" types
    [ERROR] no-public-vendor-type-leak     \"default\" references \"@typescript-eslint/utils\" types
  src/server/lsp-server.ts: 2 diagnostics
    [WARN]  no-distant-folder-import       5 folder hops > max 4
    [WARN]  no-cross-domain-sibling-import server → rules
  src/server/workspace-engine.ts: 5 diagnostics
    [WARN]  no-distant-folder-import       cache, 5 hops
    [WARN]  no-distant-folder-import       api, 5 hops
    [WARN]  no-cross-domain-sibling-import cache, server → rules
    [WARN]  no-cross-domain-sibling-import api, server → rules
    [WARN]  file-implicit-boundary-module  2 deps + 2 impl + 4 exports
  src/rules/architecture/index.ts: 0 diagnostics
```

These are the SAME findings `pnpm lint` reports for the same files. LSP path and ESLint path agree on the diagnostic set — Phase 5b's `diagnosticsHash` property preserved through the full LSP pipeline.

## Claude Code install path

Verified end-to-end:

```bash
$ claude plugin validate .claude-plugin/plugin.json
✔ Validation passed

$ claude plugin marketplace add /home/tapanc/agent-code-guard
✔ Successfully added marketplace: agent-code-guard

$ claude plugin install agent-code-guard@agent-code-guard
✔ Successfully installed plugin: agent-code-guard@agent-code-guard (scope: user)

$ claude plugin list | grep -A3 agent-code-guard
❯ agent-code-guard@agent-code-guard
    Version: 0.1.0
    Scope: user
    Status: ✔ enabled
```

Manifest correctly copied to `~/.claude/plugins/cache/agent-code-guard/agent-code-guard/0.1.0/.claude-plugin/plugin.json`; `dist/server/index.js` shipped alongside.

## Coverage

940 tests still pass. 0 lint errors. 19 warnings (the cross-domain warnings the dogfood specifically surfaced — they're real architectural signals about server/ depending on rules/, addressed by a future facade refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)